### PR TITLE
Restore controls during fullscreen playback

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -3426,6 +3426,11 @@ class MainActivity : AppCompatActivity(),
 
     private fun attachFullscreenDoubleTapListener(targetView: View) {
         val detector = GestureDetector(this, object : SimpleOnGestureListener() {
+            override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                toggleFullscreenPlayback()
+                return true
+            }
+
             override fun onDoubleTap(e: MotionEvent): Boolean {
                 hideFullScreenCustomView()
                 return true
@@ -3442,6 +3447,16 @@ class MainActivity : AppCompatActivity(),
 
     private fun detachFullscreenDoubleTapListener(targetView: View) {
         targetView.setOnTouchListener(null)
+    }
+
+    private fun toggleFullscreenPlayback() {
+        val manager = audioManager ?: return
+
+        val downEvent = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+        val upEvent = KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+
+        manager.dispatchMediaKeyEvent(downEvent)
+        manager.dispatchMediaKeyEvent(upEvent)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
## Summary
- keep the fullscreen WebChrome custom view inside the left eye container so the cursor, anchored keyboard and navigation controls remain usable
- only hide the WebView during fullscreen playback to preserve the rest of the UI layering
- add a double-tap gesture to fullscreen playback to exit back to the standard layout

## Testing
- ⚠️ `./gradlew :app:assembleDebug` (fails: Android SDK missing in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691df5ddb5d083209af5a8a8399c291b)