### PR TITLE
Add working directory guidance for environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Guidelines
+
+- Always start work in the repository root (`/workspace/TAPLINKX3`). Run `pwd` to confirm and `cd /workspace/TAPLINKX3` if needed before executing commands.
+- Use the Gradle wrapper (`./gradlew`) from the root when running builds or tests so relative paths resolve correctly.
+- Keep documentation concise and actionable when describing setup or environment steps.

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -1,0 +1,23 @@
+# Environment Setup for TapLink X3
+
+Follow these steps to ensure commands run from the correct working directory and the Gradle wrapper resolves paths properly.
+
+1. **Move to the repo root**
+   ```bash
+   cd /workspace/TAPLINKX3
+   pwd  # should output /workspace/TAPLINKX3
+   ```
+2. **Use the Gradle wrapper**
+   ```bash
+   ./gradlew --version
+   ```
+   The wrapper resolves project-relative paths; avoid invoking a system-wide `gradle` binary.
+3. **Optional: export a helper alias**
+   Add this to your shell profile if you frequently open new sessions:
+   ```bash
+   echo "alias taplinkx3='cd /workspace/TAPLINKX3'" >> ~/.bashrc
+   source ~/.bashrc
+   ```
+   Then run `taplinkx3` to jump directly into the repository before running tasks.
+
+With the working directory set to the repo root, environment setup should no longer mis-detect paths when running builds or tests.


### PR DESCRIPTION
## Summary
- add agent guidelines ensuring tasks start from repository root
- document environment setup steps to enforce correct working directory usage

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0cff48f08320911925e544b61bd6)