### PR TITLE
Add tap listener to close fullscreen media on tap

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -3403,12 +3403,21 @@ class MainActivity : AppCompatActivity(),
         dualWebViewGroup.showFullScreenOverlay(view)
         cursorLeftView.visibility = View.GONE
         cursorRightView.visibility = View.GONE
+
+        view.setOnTouchListener { _, event ->
+            if (event.action == MotionEvent.ACTION_UP) {
+                onBackPressedDispatcher.onBackPressed()
+            }
+            false
+        }
     }
 
     private fun hideFullScreenCustomView() {
         if (fullScreenCustomView == null) {
             return
         }
+
+        fullScreenCustomView?.setOnTouchListener(null)
         dualWebViewGroup.hideFullScreenOverlay()
         fullScreenCustomView = null
 


### PR DESCRIPTION
## Summary
- add a tap listener to fullscreen custom views to trigger a back press and exit
- remove the listener when the fullscreen view is hidden

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0e059f188320902e96c4779a36d3)