### PR TITLE
Add tap listener to exit fullscreen overlay

### DIFF
--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -197,6 +197,8 @@ class DualWebViewGroup @JvmOverloads constructor(
         clipToPadding = true
         setBackgroundColor(Color.BLACK)
         visibility = View.GONE
+        isClickable = true
+        isFocusable = true
     }
 
     private val fullScreenHiddenViews: List<View> by lazy {
@@ -1590,6 +1592,11 @@ class DualWebViewGroup @JvmOverloads constructor(
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
         Log.d("GestureDebug", "DualWebViewGroup onInterceptTouchEvent: ${ev.action}")
 
+        if (fullScreenOverlayContainer.visibility == View.VISIBLE) {
+            fullScreenTapDetector.onTouchEvent(ev)
+            return true
+        }
+
         if (keyboardContainer.visibility == View.VISIBLE && isAnchored) {
             val localCoords = computeAnchoredKeyboardCoordinates()
             if (localCoords != null) {
@@ -1721,6 +1728,11 @@ class DualWebViewGroup @JvmOverloads constructor(
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         val kbVisible = (keyboardContainer.visibility == View.VISIBLE)
+
+        if (fullScreenOverlayContainer.visibility == View.VISIBLE) {
+            fullScreenTapDetector.onTouchEvent(event)
+            return true
+        }
 
         if (kbVisible && isAnchored) {
             when (event.action) {


### PR DESCRIPTION
## Summary
- add a gesture detector to catch single taps on the fullscreen overlay
- route taps to the activity back dispatcher so fullscreen YouTube videos can be dismissed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0e059f188320902e96c4779a36d3)