### PR TITLE
Update documentation and add sideloading guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ TapLink X3 is an Android-based browser shell designed for XR headsets that mirro
 <a href="https://www.buymeacoffee.com/informaltech" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 ## Highlights
 
-- **Dual-eye rendering** that mirrors a single `WebView` into a left-eye clip with a cursor and a right-eye `SurfaceView` preview. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L40-L84】
-- **Custom keyboard** with anchored and focus-driven modes, supporting casing toggles, symbol layouts, and dynamic buttons wired through `CustomKeyboardView`. 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L101-L339】
-- **Navigation and triple-click overlays** supplying quick actions, bookmarking, and anchor toggles from `DualWebViewGroup` and `TripleClickMenu`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L90-L148】【F:app/src/main/java/com/TapLink/app/tripleClickMenu.kt†L72-L190】
-- **Persistent bookmarks** managed through `BookmarksView` with storage handled by `BookmarkManager`. 【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L24-L120】
+- **Dual-eye rendering** that mirrors a single `WebView` into a left-eye clip with a cursor and a right-eye `SurfaceView` preview. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L51-L121】
+- **Custom keyboard** with anchored and focus-driven modes, supporting casing toggles, symbol layouts, and dynamic buttons wired through `CustomKeyboardView`. 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L716】
+- **Navigation and triple-click overlays** supplying quick actions, bookmarking, and anchor toggles from `DualWebViewGroup` and `TripleClickMenu`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1592-L1774】【F:app/src/main/java/com/TapLink/app/tripleClickMenu.kt†L72-L160】
+- **Persistent bookmarks** managed through `BookmarksView` with storage handled by `BookmarkManager`. 【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L21-L156】【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L640-L718】
 
 ## Project layout
 
@@ -30,7 +30,7 @@ TapLink X3 is an Android-based browser shell designed for XR headsets that mirro
 
 ## Build & run
 
-1. Install Android Studio (Giraffe or newer) with Android SDK 33.
+1. Install Android Studio (Giraffe or newer) with Android SDK 34.
 2. Import the repository as a Gradle project.
 3. Select the `app` run configuration and deploy to an Android 10 (API 29) or newer device/headset.
 4. The default start URL is derived from the bookmark home entry; the keyboard opens via the navigation bar or triple-click menu.
@@ -42,9 +42,14 @@ Gradle wrapper commands are available for CI:
 ./gradlew test
 ```
 
+### Installation & sideloading
+
+- To install without Android Studio, build or download the APK and sideload it onto your headset/phone. A step-by-step walkthrough is available here: https://www.youtube.com/watch?v=l3wu7x14LKY.
+- When sideloading via ADB, enable developer options on the target device and confirm that unknown sources are allowed in the headset settings before installing the APK.
+
 ## Architectural overview
 
-TapLink revolves around `MainActivity`, which wires input devices, audio, speech recognition, and the dual-eye surface. `DualWebViewGroup` hosts the left eye UI stack (navigation, keyboard container, bookmarks) and mirrors frames to the right eye. Input funnels through `CustomKeyboardView` and `LinkEditingListener` callbacks so that keyboard interactions can either populate the WebView or manipulate bookmark fields. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3720-L3826】【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L40-L214】
+TapLink revolves around `MainActivity`, which wires input devices, audio, speech recognition, and the dual-eye surface. `DualWebViewGroup` hosts the left eye UI stack (navigation, keyboard container, bookmarks) and mirrors frames to the right eye. Input funnels through `CustomKeyboardView` and `LinkEditingListener` callbacks so that keyboard interactions can either populate the WebView or manipulate bookmark fields. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3990】【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L51-L214】
 
 ### Core data flow
 
@@ -74,14 +79,14 @@ flowchart LR
     Bookmarks -->|BookmarkListener| MA
 ```
 
-This chart captures how controller, speech, and touch events enter `MainActivity`, which orchestrates the `DualWebViewGroup`. Keyboard callbacks loop through the `OnKeyboardActionListener` interface implemented by `MainActivity` to ultimately send text or commands to the `WebView` or bookmark editors. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3720-L3826】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L101-L339】
+This chart captures how controller, speech, and touch events enter `MainActivity`, which orchestrates the `DualWebViewGroup`. Keyboard callbacks loop through the `OnKeyboardActionListener` interface implemented by `MainActivity` to ultimately send text or commands to the `WebView` or bookmark editors. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3940】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】
 
 ## Input modes
 
 TapLink exposes two complementary keyboard modes:
 
-- **Anchored mode**: The keyboard is fixed in the viewport and taps are redirected based on the cursor location. Drag and fling listeners are suppressed so only discrete taps are processed. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1495-L1689】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L207】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L626-L716】
-- **Free (focus) mode**: The keyboard is navigated via horizontal drags and flings that move the focus highlight before triggering `performFocusedTap()`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1689-L1708】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L626-L716】
+- **Anchored mode**: The keyboard is fixed in the viewport and taps are redirected based on the cursor location. Drag and fling listeners are suppressed so only discrete taps are processed. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1592-L1774】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L716】
+- **Free (focus) mode**: The keyboard is navigated via horizontal drags and flings that move the focus highlight before triggering `performFocusedTap()`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1650-L1664】【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1785-L1803】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L716】
 
 ### Anchored tap pipeline
 
@@ -102,15 +107,15 @@ sequenceDiagram
     Activity->>Web: sendCharacterToWebView / bookmark edit
 ```
 
-In anchored mode, drag and fling routines (`handleDrag`, `handleFlingEvent`) bail early so only the anchored tap path fires. Once `handleAnchoredTap` identifies the target key it forwards to `handleButtonClick`, which emits callbacks such as `onKeyPressed`, `onEnterPressed`, or `onHideKeyboard`. `MainActivity` routes those callbacks to the active destination—either the inline URL editor, bookmark panel, or the `WebView`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1495-L1689】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L339】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3720-L3826】
+In anchored mode, drag and fling routines (`handleDrag`, `handleFlingEvent`) bail early so only the anchored tap path fires. Once `handleAnchoredTap` identifies the target key it forwards to `handleButtonClick`, which emits callbacks such as `onKeyPressed`, `onEnterPressed`, or `onHideKeyboard`. `MainActivity` routes those callbacks to the active destination—either the inline URL editor, bookmark panel, or the `WebView`. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1592-L1774】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3940】
 
 ### Focus-driven tap pipeline
 
-When the keyboard is unanchored, `DualWebViewGroup` ignores anchored interception and instead forwards drag events to `CustomKeyboardView.handleDrag`, which advances the highlighted key. A tap (`ACTION_UP`) invokes `performFocusedTap()` so the currently focused button emits callbacks without cursor remapping. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1641-L1708】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L626-L716】
+When the keyboard is unanchored, `DualWebViewGroup` ignores anchored interception and instead forwards drag events to `CustomKeyboardView.handleDrag`, which advances the highlighted key. A tap (`ACTION_UP`) invokes `performFocusedTap()` so the currently focused button emits callbacks without cursor remapping. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1650-L1664】【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1785-L1803】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L716】
 
 ## Bookmark management
 
-Bookmarks persist inside `BookmarkManager`, which stores entries in shared preferences. The `BookmarksView` exposes navigation, editing, and keyboard integration via `BookmarkListener`, `BookmarkKeyboardListener`, and `BookmarkStateListener`. `MainActivity` implements these hooks to open URLs, edit titles, and inject keyboard characters. 【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L24-L230】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3775-L3826】
+Bookmarks persist inside `BookmarkManager`, which stores entries in shared preferences. The `BookmarksView` exposes navigation, editing, and keyboard integration via `BookmarkListener`, `BookmarkKeyboardListener`, and `BookmarkStateListener`. `MainActivity` implements these hooks to open URLs, edit titles, and inject keyboard characters. 【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L21-L233】【F:app/src/main/java/com/TapLink/app/BookmarksView.kt†L640-L718】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3940】
 
 ## Further reading
 

--- a/docs/anchored-mode.md
+++ b/docs/anchored-mode.md
@@ -4,9 +4,9 @@ Anchored keyboard mode pins the on-screen keyboard relative to the viewport inst
 
 ## Gesture interception
 
-When the keyboard is visible and the layout reports `isAnchored = true`, `DualWebViewGroup.onInterceptTouchEvent` checks whether the cursor projection falls inside the keyboard bounds. Any qualifying `ACTION_DOWN`, `ACTION_MOVE`, or `ACTION_UP` event is intercepted and marked as an anchored gesture. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1495-L1552】
+When the keyboard is visible and the layout reports `isAnchored = true`, `DualWebViewGroup.onInterceptTouchEvent` checks whether the cursor projection falls inside the keyboard bounds. Any qualifying `ACTION_DOWN`, `ACTION_MOVE`, or `ACTION_UP` event is intercepted and marked as an anchored gesture. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1592-L1650】
 
-`onTouchEvent` then consumes the matching `ACTION_UP` event, recalculates the cursor-aligned keyboard coordinates, and forwards the tap to `CustomKeyboardView.handleAnchoredTap`. Drag and cancel events simply keep the interception state in sync. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1553-L1689】
+`onTouchEvent` then consumes the matching `ACTION_UP` event, recalculates the cursor-aligned keyboard coordinates, and forwards the tap to `CustomKeyboardView.handleAnchoredTap`. Drag and cancel events simply keep the interception state in sync. 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1729-L1803】
 
 ```mermaid
 stateDiagram-v2
@@ -20,23 +20,23 @@ stateDiagram-v2
 
 ## Listener routing
 
-Once `handleAnchoredTap` is invoked, `CustomKeyboardView` resolves the button under the projected coordinates and emits an `OnKeyboardActionListener` callback. `MainActivity` implements this interface to distribute the action to the active surface (bookmark editor, URL bar, or WebView). 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L339】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3720-L3826】
+Once `handleAnchoredTap` is invoked, `CustomKeyboardView` resolves the button under the projected coordinates and emits an `OnKeyboardActionListener` callback. `MainActivity` implements this interface to distribute the action to the active surface (bookmark editor, URL bar, or WebView). 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3940】
 
 | Input listener | Anchored mode behavior | Relevant implementation |
 | --- | --- | --- |
-| `handleDrag` (`CustomKeyboardView`) | **Ignored** – returns immediately when `isAnchoredMode` is `true`. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L626-L716】 |
-| `handleFlingEvent` (`CustomKeyboardView`) | **Ignored** – flings short-circuit before moving focus. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L600-L646】 |
-| `performFocusedTap` (`CustomKeyboardView`) | **Unused** – taps are routed through cursor projection, not focus. | 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1631-L1708】 |
-| `handleAnchoredTap` (`CustomKeyboardView`) | **Active** – resolves the key and triggers `handleButtonClick`. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L207】【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L252-L320】 |
-| `OnKeyboardActionListener` (`MainActivity`) | **Active** – receives callbacks such as `onKeyPressed`, `onBackspacePressed`, and `onEnterPressed`. | 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3720-L3826】 |
+| `handleDrag` (`CustomKeyboardView`) | **Ignored** – returns immediately when `isAnchoredMode` is `true`. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L716】 |
+| `handleFlingEvent` (`CustomKeyboardView`) | **Ignored** – flings short-circuit before moving focus. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L648-L681】 |
+| `performFocusedTap` (`CustomKeyboardView`) | **Unused** – taps are routed through cursor projection, not focus. | 【F:app/src/main/java/com/TapLink/app/DualWebViewGroup.kt†L1785-L1803】 |
+| `handleAnchoredTap` (`CustomKeyboardView`) | **Active** – resolves the key and triggers `handleButtonClick`. | 【F:app/src/main/java/com/TapLink/app/CustomKeyboardView.kt†L173-L260】 |
+| `OnKeyboardActionListener` (`MainActivity`) | **Active** – receives callbacks such as `onKeyPressed`, `onBackspacePressed`, and `onEnterPressed`. | 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3940】 |
 
 ## Result delivery
 
 Depending on the callback, `MainActivity` performs one of three actions:
 
-1. **Bookmark navigation/editing** – when the bookmarks drawer is expanded, `onKeyPressed` and `onBackspacePressed` target `BookmarksView.handleKeyboardInput`. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3775-L3810】
-2. **URL editing** – if the inline URL field is visible, characters are inserted directly into `DualWebViewGroup.urlEditText`. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3779-L3808】
-3. **Web content input** – otherwise, characters and commands are sent to the embedded `WebView` via JavaScript bridges. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3779-L3826】
+1. **Bookmark navigation/editing** – when the bookmarks drawer is expanded, `onKeyPressed` and `onBackspacePressed` target `BookmarksView.handleKeyboardInput`. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3908】
+2. **URL editing** – if the inline URL field is visible, characters are inserted directly into `DualWebViewGroup.urlEditText`. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3848-L3899】
+3. **Web content input** – otherwise, characters and commands are sent to the embedded `WebView` via JavaScript bridges. 【F:app/src/main/java/com/TapLink/app/MainActivity.kt†L3870-L3940】
 
 This routing ensures anchored taps behave consistently regardless of which overlay is active.
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -7,11 +7,11 @@ Follow these steps to ensure commands run from the correct working directory and
    cd /workspace/TAPLINKX3
    pwd  # should output /workspace/TAPLINKX3
    ```
-2. **Use the Gradle wrapper**
+2. **Use the Gradle wrapper (with API 34 installed)**
    ```bash
    ./gradlew --version
    ```
-   The wrapper resolves project-relative paths; avoid invoking a system-wide `gradle` binary.
+   The wrapper resolves project-relative paths; avoid invoking a system-wide `gradle` binary. If you see SDK warnings, install Android API 34 to match the module's `compileSdk`/`targetSdk`.
 3. **Optional: export a helper alias**
    Add this to your shell profile if you frequently open new sessions:
    ```bash


### PR DESCRIPTION
## Summary
- refresh README highlights, architecture references, and add sideloading walkthrough link
- update anchored-mode documentation citations to current code locations
- note the API 34 toolchain requirement in the environment setup guide

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e290ebbc48320ab2a3950633b50d6)