### PR TITLE
Remove ring connection UI from navigation bar

### DIFF
--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -415,10 +415,6 @@ class DualWebViewGroup @JvmOverloads constructor(
                 left = leftNavigationBar.findViewById(R.id.btnHome),
                 right = leftNavigationBar.findViewById(R.id.btnHome)
             ),
-            "ring" to NavButton(
-                left = leftNavigationBar.findViewById(R.id.btnRingSwitch),
-                right = leftNavigationBar.findViewById(R.id.btnRingSwitch)
-            ),
             "link" to NavButton(
                 left = leftNavigationBar.findViewById(R.id.btnLink),
                 right = leftNavigationBar.findViewById(R.id.btnLink)
@@ -449,11 +445,6 @@ class DualWebViewGroup @JvmOverloads constructor(
                 isClickable = true
                 isFocusable = true
             }
-        }
-
-        navButtons["ring"]?.left?.apply {
-            isEnabled = false  // Initially disabled
-            alpha = 0.5f      // Visual feedback for disabled state
         }
 
 
@@ -2056,17 +2047,16 @@ class DualWebViewGroup @JvmOverloads constructor(
             val buttonWidth = 48
             // Adjust the padding to account for all buttons
             val usableWidth = halfWidth - 16  // Total width minus padding (8dp on each side)
-            val remainingSpace = usableWidth - (7 * buttonWidth)  // Space for 5 buttons now
-            val gap = remainingSpace / 6  // Size of each gap (now 4 gaps)
+            val remainingSpace = usableWidth - (6 * buttonWidth)
+            val gap = remainingSpace / 5  // Size of each gap
 
             // Define button zones based on layout
             val backZone     = 8..(8 + buttonWidth)
             val homeZone     = (8 +   buttonWidth +   gap)..(8 + 2*buttonWidth +   gap)
-            val ringZone     = (8 + 2*buttonWidth + 2*gap)..(8 + 3*buttonWidth + 2*gap)
-            val linkZone     = (8 + 3*buttonWidth + 3*gap)..(8 + 4*buttonWidth + 3*gap)
-            val settingsZone = (8 + 4*buttonWidth + 4*gap)..(8 + 5*buttonWidth + 4*gap)
-            val refreshZone  = (8 + 5*buttonWidth + 5*gap)..(8 + 6*buttonWidth + 5*gap)
-            val quitZone     = (8 + 6*buttonWidth + 6*gap)..(8 + 7*buttonWidth + 6*gap)
+            val linkZone     = (8 + 2*buttonWidth + 2*gap)..(8 + 3*buttonWidth + 2*gap)
+            val settingsZone = (8 + 3*buttonWidth + 3*gap)..(8 + 4*buttonWidth + 3*gap)
+            val refreshZone  = (8 + 4*buttonWidth + 4*gap)..(8 + 5*buttonWidth + 4*gap)
+            val quitZone     = (8 + 5*buttonWidth + 5*gap)..(8 + 6*buttonWidth + 5*gap)
 
             // Clear all hover states initially
             clearNavigationButtonHoverStates()
@@ -2088,16 +2078,6 @@ class DualWebViewGroup @JvmOverloads constructor(
                         button.isHovered = true
                         button.left.isHovered = true
                         button.right.isHovered = true
-                    }
-                }
-                in ringZone -> {
-                    navButtons["ring"]?.let { button ->
-                        // Only allow hover state if button is enabled
-                        if (button.left.isEnabled) {
-                            button.isHovered = true
-                            button.left.isHovered = true
-                            button.right.isHovered = true
-                        }
                     }
                 }
                 in linkZone -> {
@@ -2462,19 +2442,18 @@ class DualWebViewGroup @JvmOverloads constructor(
 
         if (y >= height - 48) {
             Log.d("AnchoredTouchDebug","handling navigation click")
-            navButtons.entries.find { it.value.isHovered }?.let { (key, button) ->
-                showButtonClickFeedback(button.left)
-                showButtonClickFeedback(button.right)
-                navigationListener?.let { listener ->
-                    when (key) {
-                        "back"     -> listener.onNavigationBackPressed()
-                        "home"     -> listener.onHomePressed()
-                        "ring"     -> listener.onRingPressed()
-                        "link"     -> listener.onHyperlinkPressed()
-                        "settings" -> listener.onSettingsPressed()
-                        "refresh"  -> listener.onRefreshPressed()
-                        "quit"     -> listener.onQuitPressed()
-                    }
+                    navButtons.entries.find { it.value.isHovered }?.let { (key, button) ->
+                        showButtonClickFeedback(button.left)
+                        showButtonClickFeedback(button.right)
+                        navigationListener?.let { listener ->
+                            when (key) {
+                                "back"     -> listener.onNavigationBackPressed()
+                                "home"     -> listener.onHomePressed()
+                                "link"     -> listener.onHyperlinkPressed()
+                                "settings" -> listener.onSettingsPressed()
+                                "refresh"  -> listener.onRefreshPressed()
+                                "quit"     -> listener.onQuitPressed()
+                            }
                 }
             }
         }
@@ -3081,11 +3060,6 @@ class DualWebViewGroup @JvmOverloads constructor(
             invalidate()
         }
     }
-
-    fun updateRingStatus(isConnected: Boolean) {
-        leftSystemInfoView.updateRingStatus(isConnected)
-    }
-
 
     fun getSettingsMenuLocation(location: IntArray) {
         settingsMenu?.getLocationOnScreen(location)

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -53,7 +53,6 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
-import android.widget.ImageButton
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
@@ -77,7 +76,6 @@ import androidx.core.content.edit
 interface NavigationListener {
     fun onNavigationBackPressed()
     fun onQuitPressed()
-    fun onRingPressed()
     fun onSettingsPressed()
     fun onRefreshPressed()
     fun onHomePressed()
@@ -286,7 +284,7 @@ class MainActivity : AppCompatActivity(),
     private var isProcessingDoubleTap = false
     private val DOUBLE_TAP_CONFIRMATION_DELAY = 200L
 
-    private var isRingSwitchEnabled = true
+    private var isRingSwitchEnabled = false
     private var settingsMenu: View? = null
 
     private val ringResponseListener = Launcher.OnResponseListener { response ->
@@ -303,25 +301,7 @@ class MainActivity : AppCompatActivity(),
                         isRingConnected = jo.getBoolean("ring_connected")
                         imuStatus = jo.getInt("ring_imu_status")
 
-                        // Update UI elements for ring status
-                        runOnUiThread {
-                            // Update ring button through DualWebViewGroup
-                            dualWebViewGroup.leftNavigationBar.findViewById<ImageButton>(R.id.btnRingSwitch)?.let { button ->
-                                button.isEnabled = isRingConnected
-                                button.alpha = if (isRingConnected) 1.0f else 0.5f
-                                // Set initial state when ring connects
-                                if (isRingConnected) {
-                                    isRingSwitchEnabled = true
-                                    button.setImageResource(R.drawable.ic_ring_enabled)
-                                } else {
-                                    isRingSwitchEnabled = false
-                                    button.setImageResource(R.drawable.ic_ring_disabled)
-                                }
-                            }
-                        }
-
-                        // Add this line to update the SystemInfoView
-                        dualWebViewGroup.updateRingStatus(isRingConnected)
+                        isRingSwitchEnabled = isRingConnected
 
                         if (isRingConnected && imuStatus != 1) {
                             RingIPCHelper.setRingIMU(this, true)
@@ -1263,13 +1243,6 @@ class MainActivity : AppCompatActivity(),
             Log.e("Sensor", "No rotation vector sensor found")
         } else {
             Log.d("Sensor", "Rotation vector sensor found")
-        }
-
-        // Get reference to ring button through DualWebViewGroup's navigation bar
-        dualWebViewGroup.leftNavigationBar.findViewById<ImageButton>(R.id.btnRingSwitch)?.apply {
-            isEnabled = false  // Initially disabled
-            alpha = 0.5f      // Visual feedback for disabled state
-            setImageResource(R.drawable.ic_ring_disabled)
         }
 
     }
@@ -3992,19 +3965,6 @@ class MainActivity : AppCompatActivity(),
         //Log.d("Navigation", "Home pressed")
         val homeUrl = dualWebViewGroup.getBookmarksView().getHomeUrl()
         webView.loadUrl(homeUrl)
-    }
-
-    // In the implementation of NavigationListener
-    override fun onRingPressed() {
-        Log.d("Navigation", "Ring switch pressed")
-        if (isRingConnected) {  // Only allow toggle if ring is connected
-            isRingSwitchEnabled = !isRingSwitchEnabled
-            // Update button icon through DualWebViewGroup
-            dualWebViewGroup.leftNavigationBar.findViewById<ImageButton>(R.id.btnRingSwitch)?.setImageResource(
-                if (isRingSwitchEnabled) R.drawable.ic_ring_enabled
-                else R.drawable.ic_ring_disabled
-            )
-        }
     }
 
     // In the implementation of NavigationListener

--- a/app/src/main/java/com/TapLink/app/SystemInfoView.kt
+++ b/app/src/main/java/com/TapLink/app/SystemInfoView.kt
@@ -26,7 +26,6 @@ class SystemInfoView @JvmOverloads constructor(
 
     private var connectivityIcon: ImageView? = null
     private var batteryIcon: ImageView? = null
-    private var ringIcon: ImageView? = null
     private var timeText: TextView? = null
     private var dateText: TextView? = null
 
@@ -78,9 +77,6 @@ class SystemInfoView @JvmOverloads constructor(
     private fun setupViews() {
         removeAllViews()
 
-        // Create and add ring icon
-        ringIcon = createIconView().also { addView(it) }
-
         // Create and add connectivity icon
         connectivityIcon = createIconView().also { addView(it) }
 
@@ -94,8 +90,6 @@ class SystemInfoView @JvmOverloads constructor(
         // Set initial values
         connectivityIcon?.setImageResource(R.drawable.wifi_off)
         batteryIcon?.setImageResource(R.drawable.battery_full)
-        // Add this line to set initial ring icon state
-        ringIcon?.setImageResource(R.drawable.ic_ring_disabled)  // Initially disabled
         timeText?.text = "--:--"
         dateText?.text = "--/--"
     }
@@ -194,13 +188,6 @@ class SystemInfoView @JvmOverloads constructor(
             Log.e("SystemInfoView", "Battery update error", e)
             batteryIcon?.setImageResource(R.drawable.battery_full)
         }
-    }
-
-    fun updateRingStatus(isConnected: Boolean) {
-        ringIcon?.setImageResource(
-            if (isConnected) R.drawable.ic_ring_enabled
-            else R.drawable.ic_ring_disabled
-        )
     }
 
     private fun updateTimeAndDate() {

--- a/app/src/main/res/layout/navigation_bar.xml
+++ b/app/src/main/res/layout/navigation_bar.xml
@@ -40,21 +40,6 @@
         android:layout_weight="1"/>
 
     <ImageButton
-        android:id="@+id/btnRingSwitch"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:src="@drawable/ic_ring_enabled"
-        android:background="@drawable/nav_button_background"
-        android:contentDescription="Toggle ring control"
-        android:padding="12dp"
-        android:scaleType="fitCenter"/>
-
-    <Space
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"/>
-
-    <ImageButton
         android:id="@+id/btnLink"
         android:layout_width="48dp"
         android:layout_height="48dp"


### PR DESCRIPTION
## Summary
- remove the ring toggle button from the navigation bar layout so it no longer appears in the bottom bar
- adjust navigation hover and click handling to cover the reduced set of buttons after the ring control removal
- keep ring connection state logic while dropping UI updates tied to the deleted button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e2d53aadc83209864828ab2cfda5e)