### PR TITLE
Improve tap handling for bookmarks and menu

### DIFF
--- a/app/src/main/java/com/TapLink/app/BookmarksView.kt
+++ b/app/src/main/java/com/TapLink/app/BookmarksView.kt
@@ -452,6 +452,37 @@ class BookmarksView @JvmOverloads constructor(
         return true
     }
 
+    fun updateSelectionFromTap(rawX: Float, rawY: Float) {
+        if (visibility != View.VISIBLE || bookmarkViews.isEmpty()) {
+            Log.d(TAG, "Ignoring tap selection update - view not visible or empty")
+            return
+        }
+
+        val tapX = rawX.toInt()
+        val tapY = rawY.toInt()
+
+        Log.d(TAG, "Updating selection from tap at ($tapX,$tapY)")
+
+        bookmarkViews.forEachIndexed { index, view ->
+            val viewLocation = IntArray(2)
+            view.getLocationOnScreen(viewLocation)
+
+            val left = viewLocation[0]
+            val top = viewLocation[1]
+            val right = left + view.width
+            val bottom = top + view.height
+
+            if (tapX in left..right && tapY in top..bottom) {
+                if (currentSelection != index) {
+                    Log.d(TAG, "Tap hit view $index, updating selection from $currentSelection")
+                    currentSelection = index
+                    updateAllSelections()
+                }
+                return
+            }
+        }
+    }
+
     private fun performAction(index: Int) {
         val bookmarks = bookmarkManager.getBookmarks()
         Log.d(TAG, "Performing action for index: $index")

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -905,10 +905,17 @@ class DualWebViewGroup @JvmOverloads constructor(
 
 
 
-    fun handleBookmarkTap(): Boolean {
+    fun handleBookmarkTap(event: MotionEvent? = null): Boolean {
         if (leftBookmarksView.visibility != View.VISIBLE) {
             Log.d("BookmarksDebug", "No tap handling - bookmarks not visible")
             return false
+        }
+
+        event?.let { tapEvent ->
+            val rawX = tapEvent.rawX
+            val rawY = tapEvent.rawY
+            Log.d("BookmarksDebug", "Updating selection from tap at ($rawX,$rawY)")
+            leftBookmarksView.updateSelectionFromTap(rawX, rawY)
         }
 
         // Let BookmarksView handle the tap

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -598,6 +598,7 @@ class MainActivity : AppCompatActivity(),
                 Log.d("TouchDebug", "checkpoint2")
 
                 if (tripleClickMenu.isMenuVisible()) {
+                    tripleClickMenu.updateFocusFromTap(e)
                     tripleClickMenu.handleTap()
                     return true
                 }
@@ -647,7 +648,7 @@ class MainActivity : AppCompatActivity(),
                     // Check if bookmarks are visible first
                     if (dualWebViewGroup.isBookmarksExpanded()) {
                         Log.d("BookmarksDebug", "Processing tap while bookmarks are visible")
-                        val handled = dualWebViewGroup.handleBookmarkTap()
+                        val handled = dualWebViewGroup.handleBookmarkTap(e)
                         if (handled) return true
                     }
 

--- a/app/src/main/java/com/TapLink/app/tripleClickMenu.kt
+++ b/app/src/main/java/com/TapLink/app/tripleClickMenu.kt
@@ -325,6 +325,31 @@ class TripleClickMenu(context: Context) : FrameLayout(context) {
         performAction(currentFocusIndex)
     }
 
+    fun updateFocusFromTap(event: MotionEvent) {
+        if (!isVisible) return
+
+        val tapX = event.rawX.toInt()
+        val tapY = event.rawY.toInt()
+
+        buttons.forEachIndexed { index, view ->
+            val location = IntArray(2)
+            view.getLocationOnScreen(location)
+
+            val left = location[0]
+            val top = location[1]
+            val right = left + view.width
+            val bottom = top + view.height
+
+            if (tapX in left..right && tapY in top..bottom) {
+                if (currentFocusIndex != index) {
+                    Log.d("MenuDebug", "Tap hit button $index, updating focus")
+                    currentFocusIndex = index
+                }
+                return
+            }
+        }
+    }
+
     private fun performAction(index: Int) {
         if (!isVisible) return
 


### PR DESCRIPTION
## Summary
- map raw tap locations to bookmark list entries before performing actions
- update triple tap menu to focus the button under the tap before executing its action
- pass tap events through from the activity so overlays respond to direct taps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f9b5bc684832090788eb50663a684)