### PR TITLE
Increase spacing around P key

### DIFF
--- a/app/src/main/res/layout/keyboard_layout.xml
+++ b/app/src/main/res/layout/keyboard_layout.xml
@@ -69,6 +69,8 @@
             android:id="@+id/button_p"
             style="@style/KeyboardButton"
             android:text="P"
+            android:layout_marginStart="6dp"
+            android:layout_marginEnd="6dp"
             android:textAllCaps="false"/>
     </LinearLayout>
 


### PR DESCRIPTION
## Summary
- widen the spacing around the P key to reduce accidental taps on adjacent keys

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa3b548708320a647bb13dc19ca2e)