### PR TITLE
Add app icon to README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![TapLink X3 app icon](app/src/main/ic_launcher-playstore.png)
+
 # TapLink X3
 
 TapLink X3 is an Android-based browser shell designed for XR headsets that mirrors a dual-eye viewport, overlays a precision cursor, and exposes a custom radial keyboard that can be anchored to the viewport or controlled via spatial gestures. The application focuses on keeping input predictable when the user is navigating web content from a wearable controller. It was originally created by u/glxblt76.


### PR DESCRIPTION
## Summary
- add the app icon image to the start of the README for immediate branding context

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692105450630832087802b3bf3ccad84)