### PR TITLE
Fix anchored bookmarks scroll delta handling

### DIFF
--- a/app/src/main/java/com/TapLink/app/BookmarksView.kt
+++ b/app/src/main/java/com/TapLink/app/BookmarksView.kt
@@ -462,14 +462,15 @@ class BookmarksView @JvmOverloads constructor(
     }
 
     // Anchored mode: handle vertical swipe to scroll
-    fun handleAnchoredSwipe(velocityY: Float) {
+    fun handleAnchoredSwipe(deltaY: Float) {
         if (!isAnchoredMode) return
-        
-        // Scroll the container based on swipe velocity
-        val scrollAmount = (velocityY * 0.5f).toInt()
-        scrollContainer.smoothScrollBy(0, -scrollAmount)
-        
-        Log.d(TAG, "Anchored swipe: velocityY=$velocityY, scrollAmount=$scrollAmount")
+
+        // Treat delta like other anchored scroll handlers for consistency
+        val scrollAmount = deltaY.toInt()
+        if (scrollAmount != 0) {
+            scrollContainer.scrollBy(0, scrollAmount)
+            Log.d(TAG, "Anchored swipe: deltaY=$deltaY, applied=$scrollAmount")
+        }
     }
 
     // Non-anchored mode: drag handling (similar to CustomKeyboardView)


### PR DESCRIPTION
## Summary
- handle anchored bookmark scrolling using delta-based movement to match other scroll handlers
- log applied scroll amounts when scrolling in anchored mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692117a67da083208b2d23710e786a12)