### PR TITLE
Remove unused navigation code and imports

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -7,8 +7,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.graphics.SurfaceTexture
-import android.hardware.Camera
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -90,10 +88,6 @@ interface LinkEditingListener {
     fun onSendClearInLink()
     fun isLinkEditing(): Boolean
 }
-
-private enum class MenuAxisLock { H, V }
-private var menuAxisLock: MenuAxisLock? = null
-private val MENU_AXIS_THRESHOLD = 6f  // tweak sensitivity
 
 class MainActivity : AppCompatActivity(),
     DualWebViewGroup.DualWebViewGroupListener,

--- a/app/src/main/java/com/TapLink/app/tripleClickMenu.kt
+++ b/app/src/main/java/com/TapLink/app/tripleClickMenu.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.graphics.Color
 import android.util.Log
 import android.view.Gravity
-import android.view.MotionEvent
 import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout


### PR DESCRIPTION
## Summary
- remove unused menu axis state and related imports from MainActivity
- drop unused MotionEvent import from triple click menu

## Testing
- ./gradlew lint (fails: Android SDK not configured in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305d6b48e883209646800a4cdf7273)