### PR TITLE
Reduce clear key text size

### DIFF
--- a/app/src/main/res/layout/keyboard_layout.xml
+++ b/app/src/main/res/layout/keyboard_layout.xml
@@ -184,6 +184,7 @@
             android:id="@+id/btn_clear"
             style="@style/KeyboardButton"
             android:text="Clear"
+            android:textSize="12sp"
             android:layout_weight="1"/>
 
         <!-- Caps key -->


### PR DESCRIPTION
## Summary
- decrease the clear keyboard button text size to avoid wrapping

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930b4165c748320b5299fa8f93312f0)