### PR TITLE
Guard touch debug logging in release builds

### DIFF
--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.util.AttributeSet
-import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -18,7 +17,7 @@ import androidx.core.view.children
 import kotlin.math.abs
 import android.view.ViewConfiguration
 
-private const val DEBUG_TOUCH = true
+private const val DEBUG_TOUCH = BuildConfig.DEBUG
 private const val TAG_TOUCH = "TouchDebug"
 class CustomKeyboardView @JvmOverloads constructor(
     context: Context,


### PR DESCRIPTION
### Motivation
- Prevent verbose touch logging from appearing in production builds to reduce log noise and potential information leakage.
- Align the touch debug toggle with the standard Android build flag for debug versus release via `BuildConfig.DEBUG`.
- Remove unused imports to keep the code clean and avoid unnecessary warnings.

### Description
- Replaced the hardcoded `DEBUG_TOUCH = true` with `DEBUG_TOUCH = BuildConfig.DEBUG` in `app/src/main/java/com/TapLink/app/CustomKeyboardView.kt` to gate logging by build type.
- Removed the now-unused `import android.util.Log` statement from the same file.
- Kept the `dbg` helper that conditionally calls `android.util.Log.d` when `DEBUG_TOUCH` is enabled.

### Testing
- No automated tests were executed as part of this change.
- Code was updated and committed successfully, and basic repository scans were used to locate the touched file and references.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f55361e8883208ead183c4307a144)