### PR TITLE
Add horizontal and vertical UI position sliders to settings for scaled non-anchored mode

### DIFF
--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -128,6 +128,54 @@
         android:paddingLeft="8dp"
         android:paddingRight="8dp"/>
 
+    <TextView
+        android:id="@+id/horizontalPositionLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Horizontal Position"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:layout_marginBottom="8dp"/>
+
+    <SeekBar
+        android:id="@+id/horizontalPositionSeekBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="40dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="8dp"
+        android:max="100"
+        android:progress="50"
+        android:progressTint="#FFFFFF"
+        android:thumbTint="#FFFFFF"
+        android:background="@drawable/nav_button_background"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"/>
+
+    <TextView
+        android:id="@+id/verticalPositionLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Vertical Position"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:layout_marginBottom="8dp"/>
+
+    <SeekBar
+        android:id="@+id/verticalPositionSeekBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="40dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="8dp"
+        android:max="100"
+        android:progress="50"
+        android:progressTint="#FFFFFF"
+        android:thumbTint="#FFFFFF"
+        android:background="@drawable/nav_button_background"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp"/>
+
     <Button
         android:id="@+id/btnCloseSettings"
         android:layout_width="wrap_content"


### PR DESCRIPTION
### Motivation
- Provide controls to nudge the scaled UI inside the available display when not in anchored mode and the UI scale is below 100%. 
- Allow users to center by default and move the screen container toward the four corners using dedicated horizontal and vertical sliders. 
- Persist the chosen offsets so layout position is restored across sessions. 

### Description
- Added two new controls to the settings layout: `horizontalPositionSeekBar` and `verticalPositionSeekBar` with labels in `res/layout/settings_layout.xml` and default progress `50` (center). 
- Added `uiPositionXProgress` and `uiPositionYProgress` fields and load/save of `uiPositionXProgress`/`uiPositionYProgress` in `DualWebViewGroup.kt`. 
- Implemented `applyUiPositionOffsets()` which computes offsets from the slider progress and `uiScale`, applies translations to `leftEyeUIContainer` and `fullScreenOverlayContainer`, and is called when scale changes, on init, and when exiting anchored mode. 
- Updated settings initialization and `dispatchSettingsTouchEvent` to handle the new sliders, and added `updatePositionSlidersVisibility()` to show the position controls only when `!isAnchored` and `uiScale` progress is less than `100`. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5a403a208320b5bd6f710e1d2525)