### PR TITLE
Fix BuildConfig reference in CustomKeyboardView

### DIFF
--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
 import android.util.AttributeSet
-import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -17,8 +16,9 @@ import android.widget.LinearLayout
 import androidx.core.view.children
 import kotlin.math.abs
 import android.view.ViewConfiguration
+import com.TapLinkX3.app.BuildConfig
 
-private const val DEBUG_TOUCH = true
+private const val DEBUG_TOUCH = BuildConfig.DEBUG
 private const val TAG_TOUCH = "TouchDebug"
 class CustomKeyboardView @JvmOverloads constructor(
     context: Context,


### PR DESCRIPTION
### Motivation
- Resolve an undefined `BuildConfig` reference so the touch debug flag compiles correctly.
- Ensure touch logging is gated by the build type using `BuildConfig.DEBUG` to avoid verbose logs in release builds.
- Remove unused imports to keep the file clean and avoid warnings.

### Description
- Added `import com.TapLinkX3.app.BuildConfig` to `app/src/main/java/com/TapLink/app/CustomKeyboardView.kt` so the `BuildConfig` symbol resolves.
- Use `private const val DEBUG_TOUCH = BuildConfig.DEBUG` to toggle touch logging by build type.
- Removed the unused `import android.util.Log` and retained the `dbg` helper which uses the fully-qualified `android.util.Log.d` call.

### Testing
- No automated tests were executed for this change.
- Local edits were compiled via commit operations but no CI/build verification was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f55361e8883208ead183c4307a144)