### PR TITLE
Fix link-enter handling and bookmark edit selection

### DIFF
--- a/app/src/main/java/com/TapLink/app/BookmarksView.kt
+++ b/app/src/main/java/com/TapLink/app/BookmarksView.kt
@@ -583,70 +583,6 @@ class BookmarksView @JvmOverloads constructor(
 
 
 
-    private fun addSpecialButton(text: String, position: Int) {
-        val isAddButton = text == "+"
-        val isCloseButton = text == "Close"
-
-        val buttonView = LinearLayout(context).apply {
-            orientation = HORIZONTAL
-            gravity = Gravity.CENTER
-            setPadding(16, 12, 16, 12)
-
-            layoutParams = LayoutParams(
-                LayoutParams.MATCH_PARENT,
-                52
-            ).apply {
-                setMargins(4, if (isAddButton) 8 else 4, 4, 4)
-            }
-
-            tag = if (isAddButton) {
-                ViewAction(ActionType.NEW)
-            } else {
-                ViewAction(ActionType.CLOSE)
-            }
-
-            background = GradientDrawable().apply {
-                when {
-                    isAddButton -> {
-                        setColor(Color.parseColor("#2069F0AE"))
-                        setStroke(1, colorAccentGreen)
-                    }
-                    isCloseButton -> {
-                        setColor(Color.parseColor("#20FFFFFF"))
-                    }
-                    else -> {
-                        setColor(colorItemDefault)
-                    }
-                }
-                cornerRadius = 12f
-            }
-
-            // Icon for the button
-            val iconView = TextView(context).apply {
-                this.text = if (isAddButton) "+" else ""
-                textSize = if (isAddButton) 20f else 0f
-                setTextColor(colorAccentGreen)
-                gravity = Gravity.CENTER
-                if (isAddButton) setPadding(0, 0, 8, 0)
-            }
-
-            // Label text
-            val labelView = TextView(context).apply {
-                this.text = if (isAddButton) "Add Bookmark" else "Close"
-                textSize = 14f
-                setTextColor(if (isAddButton) colorAccentGreen else colorTextSecondary)
-                gravity = Gravity.CENTER
-            }
-
-            if (isAddButton) addView(iconView)
-            addView(labelView)
-        }
-
-        bookmarksList.addView(buttonView)
-        bookmarkViews.add(buttonView)
-        DebugLog.d(TAG, "Added special button: $text at position $position")
-    }
-
     private fun updateSelectionBackground(view: View, isSelected: Boolean) {
         val paddingLeft = view.paddingLeft
         val paddingTop = view.paddingTop
@@ -992,9 +928,17 @@ class BookmarksView @JvmOverloads constructor(
     fun handleDoubleTap(): Boolean {
         DebugLog.d(TAG, "handleDoubleTap() called. Current selection: $currentSelection")
 
-        val bookmarks = bookmarkManager.getBookmarks()
-        if (currentSelection < bookmarks.size) {
-            val bookmark = bookmarks[currentSelection]
+        if (currentSelection !in bookmarkViews.indices) {
+            return false
+        }
+
+        val action = bookmarkViews[currentSelection].tag as? ViewAction
+        if (action?.type != ActionType.OPEN || action.id == null) {
+            return false
+        }
+
+        val bookmark = bookmarkManager.getBookmarks().find { it.id == action.id }
+        if (bookmark != null) {
             DebugLog.d(TAG, "handleDoubleTap(): About to edit bookmark ${bookmark.id} with URL: ${bookmark.url}")
 
             // Ensure keyboard listener exists and is called

--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -678,42 +678,6 @@ class CustomKeyboardView @JvmOverloads constructor(
 
 
 
-    // Modify handleFlingEvent to only use X velocity
-    fun handleFlingEvent(velocityX: Float) {
-        if (isAnchoredMode) {
-            // Ignore fling events in anchored mode
-            return
-        }
-
-        val threshold = 1000 // Adjust this value based on your AR glasses' sensitivity
-        val horizontalThreshold = 500 // Minimum velocity to consider for horizontal movement
-
-        // Log the velocity for debugging
-        DebugLog.d("KeyboardDebug", "Fling detected with velocityX=$velocityX")
-
-        if (abs(velocityX) > threshold) {
-            if (velocityX > horizontalThreshold) {
-                // Strong positive X velocity - move horizontally to the right
-                DebugLog.d("KeyboardDebug", "Forward fling - Moving horizontally")
-                moveFocusRight()
-            } else if (velocityX < -horizontalThreshold) {
-                // Strong negative X velocity - move horizontally to the left
-                DebugLog.d("KeyboardDebug", "Backward fling - Moving horizontally (left)")
-                moveFocusDown()
-            } else {
-                // Small negative velocity (close to zero) - ignore or treat as no movement
-                DebugLog.d("KeyboardDebug", "Small velocity - Ignoring fling")
-            }
-        } else {
-            // Velocity below threshold - ignore the fling
-            DebugLog.d("KeyboardDebug", "Velocity below threshold - Ignoring fling")
-        }
-
-        // Force update of key focus
-        updateKeyFocus()
-    }
-
-
     private fun getKeyboardLayout(): LinearLayout? {
         return if (childCount > 0) getChildAt(0) as? LinearLayout else null
     }

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -1277,9 +1277,6 @@ class MainActivity : AppCompatActivity(),
 
 
     override fun onSendEnterInLink() {
-        isUrlEditing = false
-        dualWebViewGroup.toggleIsUrlEditing(false)
-        isKeyboardVisible = false
         if (dualWebViewGroup.isUrlEditing()) {
             val url = dualWebViewGroup.getCurrentLinkText()
             val formattedUrl = formatUrl(url)
@@ -1287,6 +1284,9 @@ class MainActivity : AppCompatActivity(),
             dualWebViewGroup.hideLinkEditing()
             hideCustomKeyboard()
         }
+        isUrlEditing = false
+        dualWebViewGroup.toggleIsUrlEditing(false)
+        isKeyboardVisible = false
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {


### PR DESCRIPTION
### Motivation
- Ensure navigating to a URL entered in the shared link editor actually occurs before clearing edit state flags.
- Prevent accidental editing for non-bookmark entries by validating which bookmark view is selected.
- Remove dead/unused helper code related to keyboard fling handling and special bookmark buttons to simplify the codebase.

### Description
- Reordered `onSendEnterInLink` so the edited URL is formatted and loaded via `webView.loadUrl(...)` before clearing `isUrlEditing`, calling `toggleIsUrlEditing(false)`, and resetting `isKeyboardVisible` in `MainActivity.kt`.
- Tightened `handleDoubleTap` in `BookmarksView.kt` to first validate the selected view index and its `tag` as a `ViewAction`, then require `action.type == ActionType.OPEN` and a non-null `action.id` before looking up the bookmark and starting edit mode via `startEditWithId`.
- Removed the unused `addSpecialButton` implementation from `BookmarksView.kt` and deleted the `handleFlingEvent` method from `CustomKeyboardView.kt` to eliminate dead code paths.
- Added/retained debug logging around bookmark editing and keyboard visibility transitions to aid future debugging.

### Testing
- No automated tests were run for this change (review-only changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c239008cc8320a05007e415f873df)