### PR TITLE
Centralize simulated-touch handling and prevent duplicate taps while preserving WebView media playback

### DIFF
--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -7233,8 +7233,8 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                         // Check if any other media is playing before saying paused
                         const allMedia = document.querySelectorAll('video, audio');
                         let anyPlaying = false;
-                        for(let i=0; i<allMedia.length; i++) {
-                            if(!allMedia[i].paused && !allMedia[i].ended && allMedia[i].readyState > 2) {
+                        for (let i = 0; i < allMedia.length; i++) {
+                            if (!allMedia[i].paused && !allMedia[i].ended) {
                                 anyPlaying = true;
                                 break;
                             }
@@ -7244,10 +7244,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                     });
                     
                     media.addEventListener('ended', function() {
-                         const allMedia = document.querySelectorAll('video, audio');
+                        const allMedia = document.querySelectorAll('video, audio');
                         let anyPlaying = false;
-                        for(let i=0; i<allMedia.length; i++) {
-                            if(!allMedia[i].paused && !allMedia[i].ended && allMedia[i].readyState > 2) {
+                        for (let i = 0; i < allMedia.length; i++) {
+                            if (!allMedia[i].paused && !allMedia[i].ended) {
                                 anyPlaying = true;
                                 break;
                             }


### PR DESCRIPTION
### Motivation
- Fix a logic bug where allowing touches to pass through to the WebView caused media to immediately pause and not resume. 
- Prevent duplicate taps from being dispatched during cursor-driven simulated clicks while still allowing scroll-mode touch-through. 
- Reduce duplicated flag manipulation for simulated touch state to avoid stuck states and make timeouts predictable.

### Description
- Added `beginSimulatedTouch(timeoutMs: Long = simulatedTouchTimeoutMs)` and `endSimulatedTouch()` to centralize `isSimulatingTouchEvent` management using a `Handler` timeout. 
- Updated touch-listener logic to return `isCursorVisible` when `isSimulatingTouchEvent` is true so touches are consumed only while the cursor is visible, preventing unintended touch-through that paused media. 
- Replaced direct `isSimulatingTouchEvent` assignments across the file with `beginSimulatedTouch()`/`endSimulatedTouch()` calls to ensure consistent timeout cancellation and cleanup. 
- Relaxed injected JS media checks to consider media playing when `!paused && !ended` and removed the automatic background `pauseBackgroundMedia()` call from `WebAppInterface.onMediaPlaying` to avoid forcibly stopping background WebViews.

### Testing
- No automated tests were run for this change.
- No CI was executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977066eb7f88320997392a0fd30d394)