### PR TITLE
Clean up lint warnings in MainActivity and DualWebViewGroup

### DIFF
--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -167,8 +167,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 setBackgroundColor(Color.TRANSPARENT)
                 visibility = View.GONE
             }
-    private val nButtons = 7
-    private val buttonHeight = toggleButtonSizePx
     private val buttonFeedbackDuration = 200L
     var lastCursorX = 0f
     var lastCursorY = 0f
@@ -1790,9 +1788,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         // 1. Restore saved windows (and set active one)
         // 2. Or call createNewWindow() calls which will add a window and load the default URL.
 
-        // webViewsContainer.addView(...) -> Removed
-        // windows.add(...) -> Removed
-        // activeWindowId = ... -> Removed (remains null initially)
 
         val prefs = context.getSharedPreferences("TapLinkPrefs", Context.MODE_PRIVATE)
         isDesktopMode = prefs.getBoolean("isDesktopMode", false)
@@ -1989,7 +1984,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         // Initialize URL EditTexts
         urlEditText = setupUrlEditText(true)
 
-        // addView(urlEditText)
 
         // Bring urlEditTextLeft to front
         urlEditText.bringToFront()
@@ -2055,14 +2049,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         viewTreeObserver.addOnGlobalLayoutListener(
                 object : ViewTreeObserver.OnGlobalLayoutListener {
                     override fun onGlobalLayout() {
-                        /* Log.d("TouchDebug", """
-                            Toggle Bar Layout:
-                            Width: ${leftToggleBar.width}
-                            Height: ${leftToggleBar.height}
-                            Left: ${leftToggleBar.left}
-                            Top: ${leftToggleBar.top}
-                            Translation: (${leftToggleBar.translationX}, ${leftToggleBar.translationY})
-                        """.trimIndent()) */
                         viewTreeObserver.removeOnGlobalLayoutListener(this)
                     }
                 }
@@ -2418,16 +2404,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         val isSameView = viewHashCode == lastFullscreenViewHashCode
         lastFullscreenViewHashCode = viewHashCode
 
-        /* Log.d("FullscreenDebug", """
-            showFullScreenOverlay called:
-              Entry count: $fullscreenEntryCount
-              View class: ${view.javaClass.simpleName}
-              View hashCode: $viewHashCode
-              Same as last view: $isSameView
-              View attached: ${view.isAttachedToWindow}
-              View parent: ${view.parent?.javaClass?.simpleName ?: "null"}
-              Container child count before: ${fullScreenOverlayContainer.childCount}
-        """.trimIndent()) */
 
         // Remove from current parent if any
         if (view.parent is ViewGroup) {
@@ -2496,11 +2472,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     }
 
     fun hideFullScreenOverlay() {
-        /* Log.d("FullscreenDebug", """
-            hideFullScreenOverlay called:
-              Container child count: ${fullScreenOverlayContainer.childCount}
-              Container visibility: ${if (fullScreenOverlayContainer.visibility == View.VISIBLE) "VISIBLE" else "GONE/INVISIBLE"}
-        """.trimIndent()) */
 
         // Get reference to the view being removed for logging
         val removedView =
@@ -3811,10 +3782,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         val localX = localXContainer - kbView.x
         val localY = localYContainer - kbView.y
 
-        /* Log.d(
-            "TouchDebug",
-            "Anchored cursor mapped to keyboard local=($localX, $localY) kbSize=(${kbView.width}, ${kbView.height})"
-        ) */
 
         return Pair(localX, localY)
     }
@@ -4175,8 +4142,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 val travelX = kotlin.math.abs(event.x - downX)
                 val travelY = kotlin.math.abs(event.y - downY)
                 val wasTap = dur < 300 && travelX < 8 && travelY < 8
-                /* android.util.Log.d("TouchDebug",
-                "DWG UP: wasTap=$wasTap dur=${dur}ms travel=(${travelX},${travelY}) kbVisible=$kbVisible isAnchored=$isAnchored") */
 
                 if (wasTap && !isAnchored) {
                     // Check for potential content changes
@@ -4545,14 +4510,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
             setSelection(text.length)
             bringToFront()
             // Add logging to verify state
-            /* Log.d("DualWebViewGroup", """
-                Edit field state:
-                Text: $text
-                Visibility: $visibility
-                Parent: ${parent?.javaClass?.simpleName}
-                Position: ($x, $y)
-                Width: $width, Height: $height
-            """.trimIndent()) */
         }
         // Make sure we're in edit mode
         isBookmarkEditing = true
@@ -5690,15 +5647,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                         val parentLocation = IntArray(2)
                         leftToggleBar.getLocationOnScreen(parentLocation)
 
-                        /* Log.d("TouchDebug", """
-                            Button Touch (${v.id}):
-                            Raw touch: (${event.rawX}, ${event.rawY})
-                            Button screen location: (${location[0]}, ${location[1]})
-                            Button size: ${v.width}x${v.height}
-                            Toggle bar screen location: (${parentLocation[0]}, ${parentLocation[1]})
-                            Button relative to parent: (${v.x}, ${v.y})
-                            Layout bounds: ($left, $top, $right, $bottom)
-                        """.trimIndent()) */
 
                         false
                     }
@@ -6491,13 +6439,6 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                     return
                 }
 
-                /* Log.d("SettingsDebug", """
-                    Touch at ($x, $y)
-                    Volume seekbar at (${volumeLocation[0]}, ${volumeLocation[1]}) size ${volumeSeekBar?.width}x${volumeSeekBar?.height}
-                    Brightness seekbar at (${brightnessLocation[0]}, ${brightnessLocation[1]}) size ${brightnessSeekBar?.width}x${brightnessSeekBar?.height}
-                    Smoothness seekbar at (${smoothnessLocation[0]}, ${smoothnessLocation[1]}) size ${smoothnessSeekBar?.width}x${smoothnessSeekBar?.height}
-                    Close button at (${closeLocation[0]}, ${closeLocation[1]}) size ${closeButton?.width}x${closeButton?.height}
-                """.trimIndent()) */
             } else {
                 return
             }

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -220,7 +220,6 @@ class MainActivity :
     private val onBackPressedCallback =
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    // DebugLog.d("MainActivity", "Back key pressed")
                     when {
                         fullScreenCustomView != null -> {
                             hideFullScreenCustomView()
@@ -659,7 +658,6 @@ class MainActivity :
                                     isCursorVisible -> {
                                         // Check if this is a long press
                                         if (e.eventTime - e.downTime > longPressTimeout) {
-                                            // DebugLog.d("TouchDebug", "Long press detected,
                                             // ignoring input interaction")
                                             return true
                                         }
@@ -843,7 +841,6 @@ class MainActivity :
         }
 
         webView = dualWebViewGroup.getWebView()
-        // DebugLog.d("WebViewDebug", "Initial WebView state - URL: ${webView.url}")
 
         webView.setOnTouchListener { _, event ->
 
@@ -959,9 +956,7 @@ class MainActivity :
 
                         wasKeyboardDismissedByEnter = false
 
-                        wasKeyboardDismissedByEnter = false
                         // Log focus state
-                        // DebugLog.d("WebViewDebug", "WebView focus state: ${view?.isFocused}")
 
                         // Update scrollbar visibility based on new content
                         dualWebViewGroup.updateScrollBarsVisibility()
@@ -992,7 +987,6 @@ class MainActivity :
                             isReload: Boolean
                     ) {
                         super.doUpdateVisitedHistory(view, url, isReload)
-                        // DebugLog.d("WebDebug", "History updated - url: $url, canGoBack:
                         // ${view?.canGoBack()}")
                     }
                 }
@@ -1014,7 +1008,6 @@ class MainActivity :
 
         // Set up the listener
         dualWebViewGroup.linkEditingListener = this
-        // DebugLog.d("LinkEditing", "Set MainActivity as linkEditingListener")
 
         // Add after other listener assignments
         dualWebViewGroup.anchorToggleListener = this
@@ -3512,7 +3505,6 @@ class MainActivity :
                                 message: String?,
                                 result: android.webkit.JsResult?
                         ): Boolean {
-                            // DebugLog.d("DialogDebug", "onJsAlert: $message")
                             dualWebViewGroup.showAlertDialog(message ?: "") { result?.confirm() }
                             return true
                         }
@@ -3523,7 +3515,6 @@ class MainActivity :
                                 message: String?,
                                 result: android.webkit.JsResult?
                         ): Boolean {
-                            // DebugLog.d("DialogDebug", "onJsConfirm: $message")
                             dualWebViewGroup.showConfirmDialog(
                                     message ?: "",
                                     { result?.confirm() },
@@ -3539,7 +3530,6 @@ class MainActivity :
                                 defaultValue: String?,
                                 result: android.webkit.JsPromptResult?
                         ): Boolean {
-                            // DebugLog.d("DialogDebug", "onJsPrompt: $message")
                             dualWebViewGroup.showPromptDialog(
                                     message ?: "",
                                     defaultValue,
@@ -3555,7 +3545,6 @@ class MainActivity :
                                 message: String?,
                                 result: android.webkit.JsResult?
                         ): Boolean {
-                            // DebugLog.d("DialogDebug", "onJsBeforeUnload: $message")
                             dualWebViewGroup.showConfirmDialog(
                                     message ?: "Are you sure you want to leave this page?",
                                     { result?.confirm() },
@@ -4017,8 +4006,6 @@ class MainActivity :
         // Hide info bars when keyboard shows
         dualWebViewGroup.hideInfoBars()
 
-        // Hide info bars when keyboard shows
-        dualWebViewGroup.hideInfoBars()
 
         keyboardView?.let { keyboard ->
             // Log state before setting keyboard
@@ -4539,7 +4526,6 @@ class MainActivity :
     }
 
     override fun onRefreshPressed() {
-        // DebugLog.d("Navigation", "Refresh pressed")
         val currentUrl = webView.url
         webView.evaluateJavascript(
                 """


### PR DESCRIPTION
This PR addresses lint warnings and cleans up code in `MainActivity.kt` and `DualWebViewGroup.kt`.

Changes include:
1.  **MainActivity.kt**:
    *   Removed duplicate assignment of `wasKeyboardDismissedByEnter`.
    *   Removed duplicate call to `dualWebViewGroup.hideInfoBars()`.
    *   Removed commented out `DebugLog` statements.
2.  **DualWebViewGroup.kt**:
    *   Removed unused variables `nButtons` and `buttonHeight`.
    *   Removed commented out `Log.d` blocks.
    *   Removed commented out dead code in `init` block related to view addition.

These changes improve code hygiene and reduce noise without altering functionality.

---
*PR created automatically by Jules for task [6658929094091897951](https://jules.google.com/task/6658929094091897951) started by @informalTechCode*