### PR TITLE
Add GPS location to TapLink AI context and init on start

### DIFF
--- a/app/src/main/java/com/TapLink/app/GroqInterface.kt
+++ b/app/src/main/java/com/TapLink/app/GroqInterface.kt
@@ -81,14 +81,20 @@ class GroqInterface(private val context: Context, private val webView: WebView) 
                         // Add system prompt
                         val systemMsg = JSONObject()
                         systemMsg.put("role", "system")
-                        systemMsg.put(
-                                "content",
-                                """Your name is TapLink AI. You are a helpful AI assistant built into the TapLink X3 web browser for RayNeo X3 Pro glasses.
+
+                        var systemContent = """Your name is TapLink AI. You are a helpful AI assistant built into the TapLink X3 web browser for RayNeo X3 Pro glasses.
 The documentation for the web browser can be found here: https://github.com/informalTechCode/TAPLINKX3/tree/main/docs
 Information about the glasses it lives on can be found here: https://www.rayneo.com/products/x3-pro-ai-display-glasses
 The creator of the TapLink X3 browser is Informal Tech. Tech-tuber that makes awesome tech videos on YouTube. He is found at youtube.com/@informal-tech.
 Answer questions concisely and keep all responses human readable."""
-                        )
+
+                        val activity = findMainActivity(context)
+                        val location = activity?.getLastLocation()
+                        if (location != null) {
+                            systemContent += "\nCurrent Location: ${location.first}, ${location.second}"
+                        }
+
+                        systemMsg.put("content", systemContent)
                         messages.put(systemMsg)
 
                         // Add history

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -1140,6 +1140,14 @@ class MainActivity :
         }
     }
 
+    fun getLastLocation(): Pair<Double, Double>? {
+        return if (lastGpsLat != null && lastGpsLon != null) {
+            Pair(lastGpsLat!!, lastGpsLon!!)
+        } else {
+            null
+        }
+    }
+
     private fun ensureGpsUpdates() {
         if (gpsUpdatesRegistered) return
 

--- a/app/src/main/java/com/TapLink/app/WebAppInterface.kt
+++ b/app/src/main/java/com/TapLink/app/WebAppInterface.kt
@@ -1,6 +1,7 @@
 package com.TapLinkX3.app
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -56,10 +57,15 @@ class WebAppInterface(private val context: Context, private val webView: WebView
                         // Add system prompt
                         val systemMsg = JSONObject()
                         systemMsg.put("role", "system")
-                        systemMsg.put(
-                                "content",
-                                "You are a helpful AI assistant integrated into the TapLinkX3 dashboard."
-                        )
+
+                        var systemContent = "You are a helpful AI assistant integrated into the TapLinkX3 dashboard."
+                        val activity = findMainActivity(context)
+                        val location = activity?.getLastLocation()
+                        if (location != null) {
+                            systemContent += "\nCurrent Location: ${location.first}, ${location.second}"
+                        }
+
+                        systemMsg.put("content", systemContent)
                         messages.put(systemMsg)
 
                         // Add history
@@ -129,5 +135,14 @@ class WebAppInterface(private val context: Context, private val webView: WebView
             // Log.d("WebAppInterface", "Posting response to WebView: $escapedText")
             webView.evaluateJavascript("receiveGroqResponse('$escapedText')", null)
         }
+    }
+
+    private fun findMainActivity(context: Context): MainActivity? {
+        var ctx = context
+        while (ctx is ContextWrapper) {
+            if (ctx is MainActivity) return ctx
+            ctx = ctx.baseContext
+        }
+        return ctx as? MainActivity
     }
 }


### PR DESCRIPTION
This change initializes GPS streaming on app start (instead of waiting for a permission prompt) and makes the current latitude and longitude available to the TapLink AI chat interface. The AI's system prompt is updated to include the user's current location if available, allowing for location-aware responses.

---
*PR created automatically by Jules for task [10539834731680562753](https://jules.google.com/task/10539834731680562753) started by @informalTechCode*