### PR TITLE
Remove forced dark mode injection

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -3080,11 +3080,6 @@ class MainActivity :
                     safeBrowsingEnabled = true
                 }
 
-                // Force Dark Mode
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    @Suppress("DEPRECATION") forceDark = WebSettings.FORCE_DARK_ON
-                }
-
                 val wvVersion = getWebViewVersion() ?: "114.0.0.0"
 
                 // Store default UA for sites that require it (like Netflix)


### PR DESCRIPTION
Removes the `forceDark = WebSettings.FORCE_DARK_ON` line from `MainActivity.kt` to stop injecting black backgrounds/dark mode into web pages. Verified that no other background injection scripts exist.

---
*PR created automatically by Jules for task [10341472791416357459](https://jules.google.com/task/10341472791416357459) started by @informalTechCode*