### PR TITLE
Fix WebView permission handling for camera and microphone

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -5095,6 +5095,26 @@ class MainActivity :
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
         when (requestCode) {
+            PERMISSIONS_REQUEST_CODE -> {
+                pendingPermissionRequest?.let { request ->
+                    val grantedResources = mutableListOf<String>()
+                    permissions.forEachIndexed { index, permission ->
+                        if (grantResults[index] == PackageManager.PERMISSION_GRANTED) {
+                            if (permission == Manifest.permission.RECORD_AUDIO) {
+                                grantedResources.add(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+                            } else if (permission == Manifest.permission.CAMERA) {
+                                grantedResources.add(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+                            }
+                        }
+                    }
+                    if (grantedResources.isNotEmpty()) {
+                        request.grant(grantedResources.toTypedArray())
+                    } else {
+                        request.deny()
+                    }
+                    pendingPermissionRequest = null
+                }
+            }
             CAMERA_PERMISSION_CODE -> {
                 cameraPermissionGranted =
                         grantResults.isNotEmpty() &&

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -4345,9 +4345,9 @@ class MainActivity :
                                         requiredAndroidPermissions.add(
                                                 android.Manifest.permission.RECORD_AUDIO
                                         )
-                                        // Configure AR glasses microphone for voice assistant mode
+                                        // Configure AR glasses microphone for general recording/streaming
                                         audioManager?.setParameters(
-                                                "audio_source_record=voiceassistant"
+                                                "audio_source_record=camcorder"
                                         )
                                     }
                                     PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
@@ -4565,7 +4565,7 @@ class MainActivity :
                         when (type) {
                             "audio" ->
                                     audioManager?.setParameters(
-                                            "audio_source_record=voiceassistant"
+                                            "audio_source_record=camcorder"
                                     )
                             "video" -> {
                                 /* Handle camera initialization if needed */

--- a/app/src/test/java/com/TapLink/app/BookmarksLogicTest.kt
+++ b/app/src/test/java/com/TapLink/app/BookmarksLogicTest.kt
@@ -8,18 +8,18 @@ class BookmarksLogicTest {
     // Mock class replicating the fixed logic in BookmarksView
     // This verifies that using a single variable for the listener works as expected.
     class BookmarksViewLogic {
-        var keyboardListener: Listener? = null
+        private var _keyboardListener: Listener? = null
 
         interface Listener {
             fun onAction()
         }
 
         fun setKeyboardListener(listener: Listener) {
-            keyboardListener = listener
+            _keyboardListener = listener
         }
 
         fun triggerAction() {
-            keyboardListener?.onAction()
+            _keyboardListener?.onAction()
         }
     }
 


### PR DESCRIPTION
Fixes an issue where web-level camera and microphone permission requests from the WebView were not properly granted after user approval. This change maps the granted Android permissions back to the `pendingPermissionRequest` resources and grants them, enabling functionalities like YouTube live streaming in the browser.

---
*PR created automatically by Jules for task [2484810697019622342](https://jules.google.com/task/2484810697019622342) started by @informalTechCode*