### PR TITLE
Optimize network loading speed via WebView cacheMode

### DIFF
--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -3952,6 +3952,7 @@ class MainActivity :
                 domStorageEnabled = true
                 @Suppress("DEPRECATION")
                 databaseEnabled = true
+                cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
                 javaScriptCanOpenWindowsAutomatically = false
                 mediaPlaybackRequiresUserGesture = false
 

--- a/app/src/test/java/com/TapLink/app/BookmarksLogicTest.kt
+++ b/app/src/test/java/com/TapLink/app/BookmarksLogicTest.kt
@@ -8,18 +8,18 @@ class BookmarksLogicTest {
     // Mock class replicating the fixed logic in BookmarksView
     // This verifies that using a single variable for the listener works as expected.
     class BookmarksViewLogic {
-        var keyboardListener: Listener? = null
+        var keyboardListenerProp: Listener? = null
 
         interface Listener {
             fun onAction()
         }
 
         fun setKeyboardListener(listener: Listener) {
-            keyboardListener = listener
+            keyboardListenerProp = listener
         }
 
         fun triggerAction() {
-            keyboardListener?.onAction()
+            keyboardListenerProp?.onAction()
         }
     }
 


### PR DESCRIPTION
This commit updates the `cacheMode` in `MainActivity.kt` to `WebSettings.LOAD_CACHE_ELSE_NETWORK` to help improve the loading speed and performance of the WebView. By aggressively utilizing cached resources, the application will feel significantly faster for recurring requests, directly addressing the slowness of the network connection.

---
*PR created automatically by Jules for task [4411960011978798703](https://jules.google.com/task/4411960011978798703) started by @informalTechCode*