### PR TITLE
⚡ Bolt: Remove onDraw to prevent infinite layout invalidation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-06 - [Infinite Re-render Loop in Android UI Component]
+**Learning:** Overriding `onDraw()` in an Android custom view just to call `invalidate()` on child components triggers an infinite loop of render passes, severely impacting CPU and battery life. `invalidate()` schedules a redraw, so calling it inside the redraw logic creates a cycle.
+**Action:** Never call `invalidate()` or trigger layout passes from within an `onDraw` method. Rely on state changes outside of the draw cycle to call `invalidate()`.

--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -296,24 +296,6 @@ class CustomKeyboardView @JvmOverloads constructor(context: Context, attrs: Attr
         }
     }
 
-    override fun onDraw(canvas: Canvas) {
-
-        super.onDraw(canvas)
-        // Force redraw of all buttons
-        val keyboardLayout = getChildAt(0) as? LinearLayout
-        keyboardLayout?.let { layout ->
-            for (i in 0 until layout.childCount) {
-                val row = layout.getChildAt(i) as? LinearLayout
-                row?.let { rowLayout ->
-                    for (j in 0 until rowLayout.childCount) {
-                        val button = rowLayout.getChildAt(j) as? Button
-                        button?.invalidate()
-                    }
-                }
-            }
-        }
-    }
-
     private fun handleButtonClick(button: Button) {
         val buttonId = button.id
         val buttonLabel = button.text.toString()


### PR DESCRIPTION
💡 What: Removed the overriden `onDraw` method from `CustomKeyboardView.kt` which was looping through its children and calling `invalidate()` on each.
🎯 Why: Calling `invalidate()` from inside a rendering pass (like `onDraw`) queues up another rendering pass immediately. This creates an infinite loop of redraw cycles causing immense CPU overhead and massive battery drain.
📊 Impact: Expected to significantly reduce CPU usage and drastically improve battery life when the keyboard is open or rendering.
🔬 Measurement: Verify CPU usage dropping when examining profiling logs and using the app.

---
*PR created automatically by Jules for task [14308474325058374605](https://jules.google.com/task/14308474325058374605) started by @informalTechCode*