### PR TITLE
⚡ Bolt: Remove invalidate() in onDraw()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Avoid invalidate() in onDraw()
+**Learning:** Calling `invalidate()` from within `onDraw()` in Android custom views causes infinite redraw cycles, heavily impacting CPU usage and battery performance.
+**Action:** Never call `invalidate()` or trigger view invalidations during `onDraw()`. Trigger redrawing only in response to state changes (e.g., touch events or animation callbacks).

--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -296,24 +296,6 @@ class CustomKeyboardView @JvmOverloads constructor(context: Context, attrs: Attr
         }
     }
 
-    override fun onDraw(canvas: Canvas) {
-
-        super.onDraw(canvas)
-        // Force redraw of all buttons
-        val keyboardLayout = getChildAt(0) as? LinearLayout
-        keyboardLayout?.let { layout ->
-            for (i in 0 until layout.childCount) {
-                val row = layout.getChildAt(i) as? LinearLayout
-                row?.let { rowLayout ->
-                    for (j in 0 until rowLayout.childCount) {
-                        val button = rowLayout.getChildAt(j) as? Button
-                        button?.invalidate()
-                    }
-                }
-            }
-        }
-    }
-
     private fun handleButtonClick(button: Button) {
         val buttonId = button.id
         val buttonLabel = button.text.toString()


### PR DESCRIPTION
⚡ Bolt: Remove invalidate() in onDraw()

💡 What: Removed `onDraw` method containing an inner `invalidate()` loop in `CustomKeyboardView.kt`.
🎯 Why: Calling `invalidate()` within `onDraw()` causes an infinite render loop in Android, severely pegging the UI thread and consuming battery.
📊 Impact: Completely eliminates an infinite redraw cycle for the custom keyboard, drastically improving idle CPU usage and preserving battery.
🔬 Measurement: Verified with `./gradlew assembleDebug` and testing layout updates. CPU usage should now flatline when the keyboard is idle.

---
*PR created automatically by Jules for task [6977822795931788790](https://jules.google.com/task/6977822795931788790) started by @informalTechCode*