### PR TITLE
⚡ Bolt: Remove object allocations from hover event loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-05-08 - Infinite Re-render Loop in `DualWebViewGroup.kt`
 **Learning:** `dispatchDraw` was overridden solely to call `invalidate()` on child views. Since `dispatchDraw` is part of the drawing pass, calling `invalidate()` from it queues another drawing pass, causing an infinite loop. This severe anti-pattern saturated the UI thread and consumed unnecessary CPU/battery.
 **Action:** Removed the overridden `dispatchDraw`. Invalidations should only be triggered by external state or layout changes, never from within the rendering pipeline itself (`onDraw`, `dispatchDraw`).
+## 2025-05-09 - Avoid Local Object Allocations in Hover/Touch Event Loops
+**Learning:** Allocating collections like `listOf(...)` or lambdas inside high-frequency touch event or hover loops (like `updateButtonHoverStates`) causes high memory churn. This forces the Android Garbage Collector to run frequently, leading to skipped frames and UI jank.
+**Action:** Extract constant data structures and object arrays (e.g., arrays of Resource IDs, lists of Triples/lambdas) out of the method into class-level or instance-level properties. Reuse them to completely eliminate allocations on the hot path.

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -54,6 +54,37 @@ class DualWebViewGroup
 constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0) :
         ViewGroup(context, attrs, defStyleAttr) {
 
+    private val settingsElements = listOf(
+        R.id.volumeSeekBar,
+        R.id.brightnessSeekBar,
+        R.id.btnToggleForceDark,
+        R.id.smoothnessSeekBar,
+        R.id.screenSizeSeekBar,
+        R.id.btnResetScreenSize,
+        R.id.fontSizeSeekBar,
+        R.id.btnResetFontSize,
+        R.id.btnResetWebpageZoom,
+        R.id.colorWheelView,
+        R.id.btnResetTextColor,
+        R.id.horizontalPosSeekBar,
+        R.id.verticalPosSeekBar,
+        R.id.btnResetPosition,
+        R.id.btnHelp,
+        R.id.btnCloseSettings,
+        R.id.btnGroqApiKey
+    )
+
+    private val toggleBarButtons = listOf(
+        Triple(R.id.btnModeToggle, "ModeToggle") { isHoveringModeToggle = true },
+        Triple(R.id.btnYouTube, "Dashboard") { isHoveringDashboardToggle = true },
+        Triple(R.id.btnBookmarks, "Bookmarks") { isHoveringBookmarksMenu = true },
+        Triple(R.id.btnZoomOut, "ZoomOut") { isHoveringZoomOut = true },
+        Triple(R.id.btnZoomIn, "ZoomIn") { isHoveringZoomIn = true },
+        Triple(R.id.btnMask, "Mask") { isHoveringMaskToggle = true },
+        Triple(R.id.btnAnchor, "Anchor") { isHoveringAnchorToggle = true }
+    )
+
+
     // Custom WebView to expose protected scroll methods
     private inner class InternalWebView(context: Context) : WebView(context) {
         fun getHorizontalScrollRange() = super.computeHorizontalScrollRange()
@@ -5046,16 +5077,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         }
 
         // Check left toggle bar buttons
-        val toggleBarButtons =
-                listOf(
-                        Triple(R.id.btnModeToggle, "ModeToggle") { isHoveringModeToggle = true },
-                        Triple(R.id.btnYouTube, "Dashboard") { isHoveringDashboardToggle = true },
-                        Triple(R.id.btnBookmarks, "Bookmarks") { isHoveringBookmarksMenu = true },
-                        Triple(R.id.btnZoomOut, "ZoomOut") { isHoveringZoomOut = true },
-                        Triple(R.id.btnZoomIn, "ZoomIn") { isHoveringZoomIn = true },
-                        Triple(R.id.btnMask, "Mask") { isHoveringMaskToggle = true },
-                        Triple(R.id.btnAnchor, "Anchor") { isHoveringAnchorToggle = true }
-                )
+
 
         for ((buttonId, _, setHoverFlag) in toggleBarButtons) {
             val button = leftToggleBar.findViewById<View>(buttonId)
@@ -5083,26 +5105,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         // Check settings window elements if visible
         if (isSettingsVisible) {
             settingsMenu?.let { menu ->
-                val settingsElements =
-                        listOf(
-                                R.id.volumeSeekBar,
-                                R.id.brightnessSeekBar,
-                                R.id.btnToggleForceDark,
-                                R.id.smoothnessSeekBar,
-                                R.id.screenSizeSeekBar,
-                                R.id.btnResetScreenSize,
-                                R.id.fontSizeSeekBar,
-                                R.id.btnResetFontSize,
-                                R.id.btnResetWebpageZoom,
-                                R.id.colorWheelView,
-                                R.id.btnResetTextColor,
-                                R.id.horizontalPosSeekBar,
-                                R.id.verticalPosSeekBar,
-                                R.id.btnResetPosition,
-                                R.id.btnHelp,
-                                R.id.btnCloseSettings,
-                                R.id.btnGroqApiKey
-                        )
+
                 for (id in settingsElements) {
                     val view = menu.findViewById<View>(id)
                     if (isOver(view, screenX, screenY)) {
@@ -5408,26 +5411,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         // Clear settings hover states
         if (isSettingsVisible) {
             settingsMenu?.let { menu ->
-                val settingsElements =
-                        listOf(
-                                R.id.volumeSeekBar,
-                                R.id.brightnessSeekBar,
-                                R.id.btnToggleForceDark,
-                                R.id.smoothnessSeekBar,
-                                R.id.screenSizeSeekBar,
-                                R.id.btnResetScreenSize,
-                                R.id.fontSizeSeekBar,
-                                R.id.btnResetFontSize,
-                                R.id.btnResetWebpageZoom,
-                                R.id.colorWheelView,
-                                R.id.btnResetTextColor,
-                                R.id.horizontalPosSeekBar,
-                                R.id.verticalPosSeekBar,
-                                R.id.btnResetPosition,
-                                R.id.btnHelp,
-                                R.id.btnCloseSettings,
-                                R.id.btnGroqApiKey
-                        )
+
                 for (id in settingsElements) {
                     menu.findViewById<View>(id)?.isHovered = false
                 }


### PR DESCRIPTION
💡 What: Extracted `settingsElements` (List of integers) and `toggleBarButtons` (List of Triples with lambdas) to instance-level properties in `DualWebViewGroup.kt` instead of allocating them repeatedly inside `updateButtonHoverStates` and `clearAllHoverStates`.

🎯 Why: These methods are called constantly on every hover/touch event. Re-allocating `listOf(...)` collections and lambdas in a hot loop is an Android anti-pattern that creates significant memory churn and forces frequent Garbage Collection, causing dropped frames and UI jank.

📊 Impact: Reduces object allocations during hover events by 100% for these lists, leading to a smoother cursor and interface interaction with fewer GC pauses.

🔬 Measurement: Run `./gradlew test` to ensure no functionality is broken, and manually test UI hovering performance. Extracted logic runs at initialization instead of on-demand.

---
*PR created automatically by Jules for task [8159455413957371535](https://jules.google.com/task/8159455413957371535) started by @informalTechCode*