### PR TITLE
⚡ Bolt: Avoid object allocations in UI hot-paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,9 @@
 ## 2025-05-09 - Avoid Local Object Allocations in Hover/Touch Event Loops
 **Learning:** Allocating collections like `listOf(...)` or lambdas inside high-frequency touch event or hover loops (like `updateButtonHoverStates`) causes high memory churn. This forces the Android Garbage Collector to run frequently, leading to skipped frames and UI jank.
 **Action:** Extract constant data structures and object arrays (e.g., arrays of Resource IDs, lists of Triples/lambdas) out of the method into class-level or instance-level properties. Reuse them to completely eliminate allocations on the hot path.
+## 2026-05-12 - Pre-allocate measurement objects in UI loops
+**Learning:** Instantiating  or using  inside high-frequency touch loops (like checking ) causes heavy garbage collection churn. Destructuring lists inline is also an invalid construct for list of integers in Kotlin.
+**Action:** Extract UI calculation objects like  and simple data structures to class-level properties. Use standard  loops instead of closures or unsupported destructuring when iterating.
+## 2026-05-12 - Pre-allocate measurement objects in UI loops
+**Learning:** Instantiating Rect or using .forEach inside high-frequency touch loops causes heavy garbage collection churn.
+**Action:** Extract UI calculation objects like Rect to class-level properties. Use standard for loops instead of closures when iterating.

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -5035,6 +5035,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     }
 
     private val reusableLocation = IntArray(2)
+    private val reusableRect = android.graphics.Rect()
 
     // Add this method to handle cursor hovering
     private fun updateButtonHoverStates(screenX: Float, screenY: Float) {
@@ -5072,7 +5073,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
         // Check bottom navigation bar buttons ONLY if nav bar is visible
         if (leftNavigationBar.visibility == View.VISIBLE) {
-            navButtons.forEach { (_, navButton) ->
+            for ((_, navButton) in navButtons) {
                 if (isOver(navButton.left, screenX, screenY)) {
                     navButton.isHovered = true
                     navButton.left.isHovered = true
@@ -5641,13 +5642,12 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         if (button == null || button.visibility != View.VISIBLE) return false
 
         // Use getGlobalVisibleRect for accurate screen bounds detection
-        val rect = android.graphics.Rect()
-        if (!button.getGlobalVisibleRect(rect)) return false
+        if (!button.getGlobalVisibleRect(reusableRect)) return false
 
-        return screenX >= rect.left &&
-                screenX <= rect.right &&
-                screenY >= rect.top &&
-                screenY <= rect.bottom
+        return screenX >= reusableRect.left &&
+                screenX <= reusableRect.right &&
+                screenY >= reusableRect.top &&
+                screenY <= reusableRect.bottom
     }
 
     fun handleNavigationClick(screenX: Float, screenY: Float) {
@@ -5662,18 +5662,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         }
 
         if (leftToggleBar.visibility == View.VISIBLE) {
-            val toggleBarButtons =
-                    listOf(
-                            R.id.btnModeToggle,
-                            R.id.btnYouTube,
-                            R.id.btnBookmarks,
-                            R.id.btnZoomOut,
-                            R.id.btnZoomIn,
-                            R.id.btnMask,
-                            R.id.btnAnchor
-                    )
-
-            for (buttonId in toggleBarButtons) {
+            for ((buttonId, _, _) in toggleBarButtons) {
                 val button = leftToggleBar.findViewById<View>(buttonId)
                 if (isOver(button, screenX, screenY)) {
                     handleLeftMenuAction(buttonId)
@@ -5691,9 +5680,11 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         }
 
         if (leftNavigationBar.visibility == View.VISIBLE) {
-            navButtons.entries.firstOrNull { isOver(it.value.left, screenX, screenY) }?.let {
-                    (key, button) ->
-                triggerNavigationAction(key, button)
+            for ((key, button) in navButtons) {
+                if (isOver(button.left, screenX, screenY)) {
+                    triggerNavigationAction(key, button)
+                    break
+                }
             }
         }
     }
@@ -6004,7 +5995,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                         leftAnchorButton
                 )
 
-        orderedButtons.forEach { button ->
+        for (button in orderedButtons) {
             try {
                 button?.apply {
                     layoutParams =
@@ -6038,16 +6029,13 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
             }
         }
 
-        mapOf(
-                        leftModeToggleButton to R.id.btnModeToggle,
-                        leftDashboardButton to R.id.btnYouTube,
-                        leftBookmarksButton to R.id.btnBookmarks,
-                        leftZoomOutButton to R.id.btnZoomOut,
-                        leftZoomInButton to R.id.btnZoomIn,
-                        leftMaskButton to R.id.btnMask,
-                        leftAnchorButton to R.id.btnAnchor
-                )
-                .forEach { (button, id) -> button?.setOnClickListener { handleLeftMenuAction(id) } }
+        leftModeToggleButton?.setOnClickListener { handleLeftMenuAction(R.id.btnModeToggle) }
+        leftDashboardButton?.setOnClickListener { handleLeftMenuAction(R.id.btnYouTube) }
+        leftBookmarksButton?.setOnClickListener { handleLeftMenuAction(R.id.btnBookmarks) }
+        leftZoomOutButton?.setOnClickListener { handleLeftMenuAction(R.id.btnZoomOut) }
+        leftZoomInButton?.setOnClickListener { handleLeftMenuAction(R.id.btnZoomIn) }
+        leftMaskButton?.setOnClickListener { handleLeftMenuAction(R.id.btnMask) }
+        leftAnchorButton?.setOnClickListener { handleLeftMenuAction(R.id.btnAnchor) }
 
         leftWindowsButton.setOnClickListener {
             showButtonClickFeedback(leftWindowsButton)


### PR DESCRIPTION
💡 **What**: Extracted `android.graphics.Rect` to a reusable class-level property `reusableRect` in `DualWebViewGroup.kt` to avoid allocation inside the `isOver` method. Replaced inline `listOf(...)` list instantiations with the existing class-level `toggleBarButtons`. Converted inline lambda collections like `.forEach` to standard `for` loops in hot touch event loops (`updateButtonHoverStates`, `handleNavigationClick`).

🎯 **Why**: Methods like `updateButtonHoverStates` and `handleNavigationClick` run extremely frequently during touch and hover events. Instantiating arrays, inline lists, or measurement objects like `Rect` on every frame causes significant memory churn on the UI thread, forcing the Android GC to run frequently and causing frame drops/jank.

📊 **Impact**: Reduces object allocations on the UI thread during hover/touch events to near zero in the modified paths.

🔬 **Measurement**: Verify by running `assembleDebug` and `test`. The build should pass, and the application performance (specifically CPU/GC activity during intense swiping or hovering) should be measurably smoother.

---
*PR created automatically by Jules for task [9964202309964373825](https://jules.google.com/task/9964202309964373825) started by @informalTechCode*