### PR TITLE
⚡ Bolt: Reduce allocations in high-frequency loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2024-05-14 - Mutable Shared State in Utility Functions
 **Learning:** Returning a pre-allocated object (like `reusableRect`) directly from a helper function (like `getHitRect`) can create brittle code if the calling functions hold onto those references. Even if it works sequentially, it is an anti-pattern that can lead to shared mutable state bugs later.
 **Action:** When pre-allocating objects for performance, functions should either return boolean results after doing calculations internally, copy values into caller-provided references (e.g. `outRect`), or restrict usage to immediately reading primitives before the next allocation.
+## 2024-05-19 - [Fix Missing Permission in TAP Bluetooth Controller Log]
+**Learning:** Adding a try catch inside TapLinkBluetoothControllerServer.kt caught a lint Missing Permission error for the bluetooth socket.remoteDevice.name log.
+**Action:** When working on bluetooth code wrap bluetooth actions that are only logs into try catch to bypass unneeded permission issues.

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -3598,7 +3598,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                     urlEditText.invalidate()
                 }
 
-                val captureRect = android.graphics.Rect(0, 0, halfWidth, height)
+                captureRect.set(0, 0, halfWidth, height)
                 val window = (context as Activity).window
 
                 captureInFlight = true
@@ -5170,6 +5170,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     private val reusableLocation2 = IntArray(2)
     private val reusableLocation = IntArray(2)
     private val reusableRect = android.graphics.Rect()
+    private val captureRect = android.graphics.Rect()
 
     // Add this method to handle cursor hovering
     private fun updateButtonHoverStates(screenX: Float, screenY: Float, force: Boolean = false) {
@@ -5588,19 +5589,19 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
     fun dispatchScrollbarTouch(screenX: Float, screenY: Float) {
         fun getLocalPoint(container: ViewGroup): Pair<Float, Float>? {
             if (container.visibility != View.VISIBLE) return null
-            val rect = android.graphics.Rect()
-            if (!container.getGlobalVisibleRect(rect)) return null
-            if (screenX < rect.left ||
-                            screenX > rect.right ||
-                            screenY < rect.top ||
-                            screenY > rect.bottom
+
+            if (!container.getGlobalVisibleRect(reusableRect)) return null
+            if (screenX < reusableRect.left ||
+                            screenX > reusableRect.right ||
+                            screenY < reusableRect.top ||
+                            screenY > reusableRect.bottom
             ) {
                 return null
             }
             val scaleX = if (container.scaleX == 0f) 1f else container.scaleX
             val scaleY = if (container.scaleY == 0f) 1f else container.scaleY
-            val localX = (screenX - rect.left) / scaleX
-            val localY = (screenY - rect.top) / scaleY
+            val localX = (screenX - reusableRect.left) / scaleX
+            val localY = (screenY - reusableRect.top) / scaleY
             return localX to localY
         }
 

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -6358,7 +6358,7 @@ class MainActivity :
     }
 
     private fun controllerNormalizedToScreen(x: Float, y: Float): Pair<Float, Float> {
-        val groupLocation = IntArray(2)
+        val groupLocation = reusableLocation1
         dualWebViewGroup.getLocationOnScreen(groupLocation)
         return groupLocation[0] + x * CONTROLLER_CURSOR_WIDTH to
                 groupLocation[1] + y * CONTROLLER_CURSOR_HEIGHT

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
@@ -167,7 +167,7 @@ class TapLinkBluetoothControllerServer(private val context: Context) {
             try {
                 Log.d(TAG, "Waiting for accept()...")
                 val socket = serverSocket?.accept() ?: continue
-                Log.d(TAG, "Connection accepted from ${socket.remoteDevice?.name ?: "unknown"}")
+                try { Log.d(TAG, "Connection accepted from ${socket.remoteDevice?.name ?: "unknown"}") } catch (e: SecurityException) { Log.d(TAG, "Connection accepted, but missing permission to get device name.") }
 
                 // Close old connection and wait for its reader to exit
                 readerThread?.let { oldReader ->


### PR DESCRIPTION
⚡ Bolt: Reduce allocations in high-frequency loops

💡 What: Changed the allocation of `android.graphics.Rect` and `IntArray` from local variable initializations to re-used class-level properties inside `DualWebViewGroup.kt` and `MainActivity.kt`.

🎯 Why: To reduce memory churn and avoid frequent Garbage Collection (GC) pauses caused by allocating objects continuously inside very high frequency calls, such as the `captureLeftEyeContent()` rendering loop, `dispatchScrollbarTouch()` and `controllerNormalizedToScreen()`.

📊 Impact: Reduces continuous memory allocations and GC pauses improving overall application efficiency and potentially rendering loop times. 

🔬 Measurement: Verifiable by analyzing memory allocations over time with profilers or observing more steady framerates. Also fixed a preexisting minor lint missing permission problem.

---
*PR created automatically by Jules for task [2098754298998601107](https://jules.google.com/task/2098754298998601107) started by @informalTechCode*