### PR TITLE
Add "Meta Mode" for controller/touch navigation and Glass Apps compatibility

### DIFF
--- a/app/src/main/java/com/TapLink/app/Constants.kt
+++ b/app/src/main/java/com/TapLink/app/Constants.kt
@@ -14,4 +14,5 @@ object Constants {
     const val KEY_WEB_TEXT_COLOR = "webTextColor"
     const val KEY_GROQ_API_KEY = "groq_api_key"
     const val KEY_WEBVIEW_STATE = "webview_state"
+    const val KEY_META_MODE_ENABLED = "meta_mode_enabled"
 }

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -61,6 +61,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         R.id.volumeSeekBar,
         R.id.brightnessSeekBar,
         R.id.btnToggleForceDark,
+        R.id.btnToggleMetaMode,
         R.id.smoothnessSeekBar,
         R.id.screenSizeSeekBar,
         R.id.btnResetScreenSize,
@@ -6261,6 +6262,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                                 .getBoolean("forceDarkWebEnabled", true)
                 forceDarkButton?.text =
                         if (forceDarkEnabled) "Force Dark: On" else "Force Dark: Off"
+                val metaModeButton = menu.findViewById<Button>(R.id.btnToggleMetaMode)
+                val metaModeEnabled = (context as? MainActivity)?.isMetaModeEnabled() ?: false
+                metaModeButton?.text =
+                        if (metaModeEnabled) "Meta Mode: On" else "Meta Mode: Off"
 
                 // Initialize smoothness seekbar from saved preference
                 val smoothnessSeekBar = menu.findViewById<SeekBar>(R.id.smoothnessSeekBar)
@@ -6376,6 +6381,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
             val volumeSeekBar = menu.findViewById<SeekBar>(R.id.volumeSeekBar)
             val brightnessSeekBar = menu.findViewById<SeekBar>(R.id.brightnessSeekBar)
             val forceDarkButton = menu.findViewById<Button>(R.id.btnToggleForceDark)
+            val metaModeButton = menu.findViewById<Button>(R.id.btnToggleMetaMode)
             val smoothnessSeekBar = menu.findViewById<SeekBar>(R.id.smoothnessSeekBar)
             val screenSizeSeekBar = menu.findViewById<SeekBar>(R.id.screenSizeSeekBar)
             val horizontalPosSeekBar = menu.findViewById<SeekBar>(R.id.horizontalPosSeekBar)
@@ -6474,6 +6480,19 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                     forceDarkButton.isPressed = true
                     Handler(Looper.getMainLooper())
                             .postDelayed({ forceDarkButton.isPressed = false }, 100)
+                    return
+                }
+
+                val metaModeRect = getHitRect(metaModeButton, buttonSlop)
+                if (metaModeRect != null) {
+                    val mainActivity = context as? MainActivity
+                    val newEnabled = !(mainActivity?.isMetaModeEnabled() ?: false)
+                    mainActivity?.setMetaModeEnabled(newEnabled)
+                    metaModeButton.text = if (newEnabled) "Meta Mode: On" else "Meta Mode: Off"
+
+                    metaModeButton.isPressed = true
+                    Handler(Looper.getMainLooper())
+                            .postDelayed({ metaModeButton.isPressed = false }, 100)
                     return
                 }
 

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -179,19 +179,21 @@ class MainActivity :
     private var glassAppsMetaToastShownForUrl: String? = null
 
     private fun refreshCursor() {
+        if (isMetaNavigationActive()) {
+            isCursorVisible = false
+        }
         dualWebViewGroup.updateCursorPosition(lastCursorX, lastCursorY, isCursorVisible)
     }
 
     private fun refreshCursor(visible: Boolean) {
-        isCursorVisible = if (isMetaNavigationActive()) false else visible
+        isCursorVisible = visible
         refreshCursor()
     }
 
     private fun centerCursor(visible: Boolean = isCursorVisible) {
         lastCursorX = 320f
         lastCursorY = 240f
-        isCursorVisible = visible
-        refreshCursor()
+        refreshCursor(visible)
     }
 
     private fun isMousePointerEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -169,13 +169,21 @@ class MainActivity :
     private var controllerTouchDownTime = 0L
     private var isControllerConnected = false
     private var isPhoneKeyboardOpen = false
+    private var metaModeEnabled = false
+    private var metaGestureStartX = 0f
+    private var metaGestureStartY = 0f
+    private var metaGestureLastX = 0f
+    private var metaGestureLastY = 0f
+    private var metaGestureTotalDistance = 0f
+    private var savedCursorVisibleBeforeMetaMode: Boolean? = null
+    private var glassAppsMetaToastShownForUrl: String? = null
 
     private fun refreshCursor() {
         dualWebViewGroup.updateCursorPosition(lastCursorX, lastCursorY, isCursorVisible)
     }
 
     private fun refreshCursor(visible: Boolean) {
-        isCursorVisible = visible
+        isCursorVisible = if (isMetaNavigationActive()) false else visible
         refreshCursor()
     }
 
@@ -587,6 +595,10 @@ class MainActivity :
         cursorSensitivity =
                 getSharedPreferences(prefsName, MODE_PRIVATE).getInt("cursorSensitivity", 50)
         updateCursorSensitivity(cursorSensitivity)
+        metaModeEnabled =
+                getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE)
+                        .getBoolean(Constants.KEY_META_MODE_ENABLED, false)
+        applyMetaModeCursorVisibility()
 
         // Initialize GestureDetector
         gestureDetector =
@@ -673,6 +685,10 @@ class MainActivity :
                                     distanceX: Float,
                                     distanceY: Float
                             ): Boolean {
+                                if (metaModeEnabled) {
+                                    tapCount = 0
+                                    return true
+                                }
                                 tapCount = 0 // Reset tap count on scroll to prevent accidental
                                 // triple-tap detection
                                 totalScrollDistance +=
@@ -939,6 +955,10 @@ class MainActivity :
                                 return false
                             }
                             override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                                if (metaModeEnabled) {
+                                    dispatchMetaKeyToWebView("Enter")
+                                    return true
+                                }
                                 if (totalScrollDistance > 10f) {
                                     return false
                                 }
@@ -1197,8 +1217,8 @@ class MainActivity :
             lastCursorY = y
             lastKnownCursorX = x
             lastKnownCursorY = y
-            refreshCursor(true)
-            if (select) {
+            refreshCursor(!isMetaNavigationActive())
+            if (select && !isMetaNavigationActive()) {
                 dispatchTouchEventAtCursor()
             }
             dualWebViewGroup.noteUserInteraction()
@@ -1289,6 +1309,8 @@ class MainActivity :
                         if (::dualWebViewGroup.isInitialized) {
                             dualWebViewGroup.scheduleSaveAllWindowsState()
                         }
+
+                        maybeShowGlassAppsMetaModeToast(url)
 
                         // Force enable input on all potential input fields
                         webView.evaluateJavascript(
@@ -4116,6 +4138,8 @@ class MainActivity :
                                     dualWebViewGroup.injectLocation(lastGpsLat!!, lastGpsLon!!)
                                 }
 
+                                maybeShowGlassAppsMetaModeToast(url)
+
                                 // Restore media listeners and scrollbar logic from DualWebViewGroup
                                 view?.let { dualWebViewGroup.injectPageObservers(it) }
                                 dualWebViewGroup.updateScrollBarsVisibility()
@@ -5671,6 +5695,15 @@ class MainActivity :
                 }
             }
         }
+        if (metaModeEnabled && isMetaNavigationKey(event.keyCode)) {
+            val keyName = metaKeyNameForKeyCode(event.keyCode)
+            if (keyName != null) {
+                if (event.action == KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
+                    dispatchMetaKeyToWebView(keyName)
+                }
+                return true
+            }
+        }
         return super.dispatchKeyEvent(event)
     }
 
@@ -5680,8 +5713,12 @@ class MainActivity :
             ensureMouseTapModeDisabled()
         }
 
-        // Temple arm input should only be used for mode-toggle double taps.
+        // Temple arm input is normally reserved for mode-toggle double taps; in Meta mode it
+        // becomes a keyboard-navigation surface for Glass Apps compatibility.
         if (ev.device?.name == "cyttsp6_mt") {
+            if (handleMetaTouchEvent(ev)) {
+                return true
+            }
             templeDoubleTapDetector.onTouchEvent(ev)
             return true
         }
@@ -5689,6 +5726,13 @@ class MainActivity :
         autoEnterMouseModeForMudraInput(ev)
 
         val isMouseEvent = isMousePointerEvent(ev)
+
+        if (!isMouseEvent && handleMetaTouchEvent(ev)) {
+            if (::dualWebViewGroup.isInitialized) {
+                dualWebViewGroup.noteUserInteraction()
+            }
+            return true
+        }
 
         // Track state at start of touch to prevent double-dispatch issues
         if (ev.action == MotionEvent.ACTION_DOWN) {
@@ -6145,9 +6189,13 @@ class MainActivity :
             if (::cursorController.isInitialized) {
                 cursorController.onControllerModeChanged(mode)
             }
+            applyMetaModeCursorVisibility()
             dualWebViewGroup.showToast(
-                    if (mode == ControllerMode.AIR_MOUSE) "Controller air mouse"
-                    else "Controller trackpad",
+                    when (mode) {
+                        ControllerMode.AIR_MOUSE -> "Controller air mouse"
+                        ControllerMode.TRACKPAD -> "Controller trackpad"
+                        ControllerMode.META -> "Controller meta mode"
+                    },
                     1200L
             )
         }
@@ -6156,6 +6204,8 @@ class MainActivity :
     override fun onControllerKey(key: String) {
         runOnUiThread {
             when (key) {
+                "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter" ->
+                        dispatchMetaKeyToWebView(key)
                 "backspace" -> onBackspacePressed()
                 "enter" -> onEnterPressed()
                 "hideKeyboard" -> {
@@ -6214,6 +6264,10 @@ class MainActivity :
     override fun onControllerScroll(dy: Float) {
         runOnUiThread {
             if (!::dualWebViewGroup.isInitialized || !::webView.isInitialized) return@runOnUiThread
+            if (metaModeEnabled || remoteControllerMode == ControllerMode.META) {
+                dispatchMetaKeyToWebView(if (dy > 0f) "ArrowDown" else "ArrowUp")
+                return@runOnUiThread
+            }
 
             // Dispatch mouse wheel scroll event
             val pointerCoords = MotionEvent.PointerCoords()
@@ -6262,6 +6316,10 @@ class MainActivity :
             dy: Float,
             pointerCount: Int
     ) {
+        if (metaModeEnabled || remoteControllerMode == ControllerMode.META) {
+            handleMetaTrackpadGesture(action, dx, dy, pointerCount)
+            return
+        }
         if (::cursorController.isInitialized) {
             cursorController.onControllerTrackpadGesture(action, dx, dy, pointerCount)
         }
@@ -6270,6 +6328,11 @@ class MainActivity :
     override fun onControllerTap() {
         runOnUiThread {
             if (!::dualWebViewGroup.isInitialized) return@runOnUiThread
+            if (metaModeEnabled || remoteControllerMode == ControllerMode.META) {
+                dispatchMetaKeyToWebView("Enter")
+                dualWebViewGroup.noteUserInteraction()
+                return@runOnUiThread
+            }
 
             // Route through the same triple-tap detection as the temple touchpad
             val currentTime = SystemClock.uptimeMillis()
@@ -6355,6 +6418,192 @@ class MainActivity :
             }
             dualWebViewGroup.noteUserInteraction()
         }
+    }
+
+    fun setMetaModeEnabled(enabled: Boolean) {
+        if (metaModeEnabled == enabled) return
+        metaModeEnabled = enabled
+        getSharedPreferences(Constants.PREFS_NAME, MODE_PRIVATE)
+                .edit()
+                .putBoolean(Constants.KEY_META_MODE_ENABLED, enabled)
+                .apply()
+        applyMetaModeCursorVisibility()
+        if (::dualWebViewGroup.isInitialized) {
+            dualWebViewGroup.showToast(
+                    if (enabled) "Meta mode enabled: swipes send arrows, taps send Enter"
+                    else "Meta mode disabled",
+                    1800L
+            )
+        }
+    }
+
+    fun isMetaModeEnabled(): Boolean = metaModeEnabled
+
+    private fun isMetaNavigationActive(): Boolean =
+            metaModeEnabled || remoteControllerMode == ControllerMode.META
+
+    private fun applyMetaModeCursorVisibility() {
+        if (!::dualWebViewGroup.isInitialized) return
+        if (isMetaNavigationActive()) {
+            if (savedCursorVisibleBeforeMetaMode == null) {
+                savedCursorVisibleBeforeMetaMode = isCursorVisible
+            }
+            refreshCursor(false)
+        } else {
+            val shouldRestoreCursor = savedCursorVisibleBeforeMetaMode ?: return
+            savedCursorVisibleBeforeMetaMode = null
+            refreshCursor(shouldRestoreCursor)
+        }
+    }
+
+    private fun handleMetaTrackpadGesture(
+            action: ControllerTrackpadAction,
+            dx: Float,
+            dy: Float,
+            pointerCount: Int
+    ) {
+        runOnUiThread {
+            if (pointerCount > 1) return@runOnUiThread
+            when (action) {
+                ControllerTrackpadAction.DOWN -> {
+                    metaGestureStartX = 0f
+                    metaGestureStartY = 0f
+                    metaGestureLastX = 0f
+                    metaGestureLastY = 0f
+                    metaGestureTotalDistance = 0f
+                }
+                ControllerTrackpadAction.MOVE -> {
+                    metaGestureLastX += dx
+                    metaGestureLastY += dy
+                    metaGestureTotalDistance += kotlin.math.sqrt(dx * dx + dy * dy)
+                }
+                ControllerTrackpadAction.UP -> {
+                    val key = metaKeyForGesture(metaGestureLastX, metaGestureLastY, metaGestureTotalDistance)
+                    dispatchMetaKeyToWebView(key)
+                    metaGestureTotalDistance = 0f
+                }
+                ControllerTrackpadAction.CANCEL -> metaGestureTotalDistance = 0f
+                ControllerTrackpadAction.POINTER -> Unit
+            }
+        }
+    }
+
+    private fun handleMetaTouchEvent(ev: MotionEvent): Boolean {
+        if (!metaModeEnabled || isPointOnCustomUi(ev.rawX, ev.rawY)) return false
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                metaGestureStartX = ev.rawX
+                metaGestureStartY = ev.rawY
+                metaGestureLastX = ev.rawX
+                metaGestureLastY = ev.rawY
+                metaGestureTotalDistance = 0f
+                return true
+            }
+            MotionEvent.ACTION_MOVE -> {
+                val dx = ev.rawX - metaGestureLastX
+                val dy = ev.rawY - metaGestureLastY
+                metaGestureTotalDistance += kotlin.math.sqrt(dx * dx + dy * dy)
+                metaGestureLastX = ev.rawX
+                metaGestureLastY = ev.rawY
+                return true
+            }
+            MotionEvent.ACTION_UP -> {
+                val key = metaKeyForGesture(
+                        ev.rawX - metaGestureStartX,
+                        ev.rawY - metaGestureStartY,
+                        metaGestureTotalDistance
+                )
+                dispatchMetaKeyToWebView(key)
+                return true
+            }
+            MotionEvent.ACTION_CANCEL -> return true
+        }
+        return false
+    }
+
+    private fun metaKeyForGesture(dx: Float, dy: Float, totalDistance: Float): String {
+        val distance = kotlin.math.sqrt(dx * dx + dy * dy)
+        val swipeThreshold = 36f
+        return if (distance < swipeThreshold && totalDistance < swipeThreshold * 1.5f) {
+            "Enter"
+        } else if (kotlin.math.abs(dx) > kotlin.math.abs(dy)) {
+            if (dx < 0f) "ArrowLeft" else "ArrowRight"
+        } else {
+            if (dy < 0f) "ArrowUp" else "ArrowDown"
+        }
+    }
+
+    private fun dispatchMetaKeyToWebView(keyName: String) {
+        if (!::webView.isInitialized) return
+        val keyCode =
+                when (keyName) {
+                    "ArrowUp" -> KeyEvent.KEYCODE_DPAD_UP
+                    "ArrowDown" -> KeyEvent.KEYCODE_DPAD_DOWN
+                    "ArrowLeft" -> KeyEvent.KEYCODE_DPAD_LEFT
+                    "ArrowRight" -> KeyEvent.KEYCODE_DPAD_RIGHT
+                    "Enter" -> KeyEvent.KEYCODE_ENTER
+                    else -> return
+                }
+        val now = SystemClock.uptimeMillis()
+        webView.dispatchKeyEvent(KeyEvent(now, now, KeyEvent.ACTION_DOWN, keyCode, 0))
+        webView.dispatchKeyEvent(KeyEvent(now, now, KeyEvent.ACTION_UP, keyCode, 0))
+
+        val code = if (keyName == "Enter") "Enter" else keyName
+        val which =
+                when (keyName) {
+                    "ArrowUp" -> 38
+                    "ArrowDown" -> 40
+                    "ArrowLeft" -> 37
+                    "ArrowRight" -> 39
+                    "Enter" -> 13
+                    else -> return
+                }
+        webView.evaluateJavascript(
+                """
+            (function() {
+                const key = ${JSONObject.quote(keyName)};
+                const code = ${JSONObject.quote(code)};
+                const which = $which;
+                const target = document.activeElement || document.body || document.documentElement;
+                const init = {key, code, which, keyCode: which, bubbles: true, cancelable: true};
+                target.dispatchEvent(new KeyboardEvent('keydown', init));
+                target.dispatchEvent(new KeyboardEvent('keyup', init));
+            })();
+        """.trimIndent(),
+                null
+        )
+        if (::dualWebViewGroup.isInitialized) {
+            dualWebViewGroup.noteUserInteraction()
+        }
+    }
+
+    private fun isMetaNavigationKey(keyCode: Int): Boolean =
+            metaKeyNameForKeyCode(keyCode) != null
+
+    private fun metaKeyNameForKeyCode(keyCode: Int): String? =
+            when (keyCode) {
+                KeyEvent.KEYCODE_DPAD_UP -> "ArrowUp"
+                KeyEvent.KEYCODE_DPAD_DOWN -> "ArrowDown"
+                KeyEvent.KEYCODE_DPAD_LEFT -> "ArrowLeft"
+                KeyEvent.KEYCODE_DPAD_RIGHT -> "ArrowRight"
+                KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER -> "Enter"
+                else -> null
+            }
+
+    private fun maybeShowGlassAppsMetaModeToast(url: String?) {
+        val host = runCatching { url?.let { Uri.parse(it).host } }.getOrNull() ?: return
+        if (!host.equals("glassapps.io", ignoreCase = true) &&
+                        !host.endsWith(".glassapps.io", ignoreCase = true)
+        ) {
+            return
+        }
+        if (glassAppsMetaToastShownForUrl == url) return
+        glassAppsMetaToastShownForUrl = url
+        dualWebViewGroup.showToast(
+                if (metaModeEnabled) "Meta mode is enabled for Glass Apps"
+                else "For maximum compatibility on Glass Apps, enable Meta mode in Settings.",
+                3500L
+        )
     }
 
     private fun controllerNormalizedToScreen(x: Float, y: Float): Pair<Float, Float> {

--- a/app/src/main/java/com/TapLink/app/controller/ControllerBluetoothClient.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerBluetoothClient.kt
@@ -410,6 +410,7 @@ class ControllerBluetoothClient(
             when (value) {
                 "airMouse" -> ControllerMode.AIR_MOUSE
                 "trackpad" -> ControllerMode.TRACKPAD
+                "meta" -> ControllerMode.META
                 else -> null
             }
 

--- a/app/src/main/java/com/TapLink/app/controller/ControllerInputProtocol.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerInputProtocol.kt
@@ -22,7 +22,8 @@ interface ControllerInputListener {
 
 enum class ControllerMode {
     AIR_MOUSE,
-    TRACKPAD
+    TRACKPAD,
+    META
 }
 
 enum class ControllerTrackpadAction {

--- a/app/src/main/res/layout/settings_layout.xml
+++ b/app/src/main/res/layout/settings_layout.xml
@@ -118,6 +118,19 @@
             android:textAllCaps="false"
             android:clickable="true"
             android:focusable="true"
+            android:layout_marginBottom="6dp"/>
+
+        <Button
+            android:id="@+id/btnToggleMetaMode"
+            android:layout_width="match_parent"
+            android:layout_height="28dp"
+            android:text="Meta Mode: Off"
+            android:textColor="#82B1FF"
+            android:textSize="11sp"
+            android:background="@drawable/settings_outlined_button_background"
+            android:textAllCaps="false"
+            android:clickable="true"
+            android:focusable="true"
             android:layout_marginBottom="10dp"/>
 
         <!-- Anchor Smoothness -->

--- a/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
@@ -64,6 +64,8 @@ class MainActivity : Activity(), SensorEventListener {
     private var touchStartX = 0f
     private var touchStartY = 0f
     private var totalTouchDistance = 0f
+    private var metaGestureStartX = 0f
+    private var metaGestureStartY = 0f
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -493,15 +495,26 @@ class MainActivity : Activity(), SensorEventListener {
                                 setPadding(dp(8), dp(8), dp(16), dp(8))
                             }
                     )
+                    addView(
+                            RadioButton(this@MainActivity).apply {
+                                text = "Meta"
+                                setTextColor(Color.parseColor("#e2e8f0"))
+                                id = View.generateViewId()
+                                setPadding(dp(8), dp(8), dp(16), dp(8))
+                            }
+                    )
                     setOnCheckedChangeListener { group, checkedId ->
                         flushPendingTrackpadDelta()
                         val checked = group.findViewById<RadioButton>(checkedId)
                         mode =
-                                if (checked.text.toString().contains("Air")) {
-                                    hasBaseline = false
-                                    TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
-                                } else {
-                                    TapLinkBluetoothControllerServer.ControllerMode.TRACKPAD
+                                when {
+                                    checked.text.toString().contains("Air") -> {
+                                        hasBaseline = false
+                                        TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
+                                    }
+                                    checked.text.toString().contains("Meta") ->
+                                            TapLinkBluetoothControllerServer.ControllerMode.META
+                                    else -> TapLinkBluetoothControllerServer.ControllerMode.TRACKPAD
                                 }
                         controllerServer.setMode(mode)
                         updateModeChrome()
@@ -540,7 +553,8 @@ class MainActivity : Activity(), SensorEventListener {
                     setOnTouchListener(::handleTrackpadTouch)
                     addView(
                             TextView(this@MainActivity).apply {
-                                text = "Trackpad Area"
+                                id = android.R.id.text1
+                                text = if (mode == TapLinkBluetoothControllerServer.ControllerMode.META) "Meta Mode\nSwipe arrows • tap Enter" else "Trackpad Area"
                                 setTextColor(Color.parseColor("#64748b"))
                                 textSize = 20f
                                 gravity = Gravity.CENTER
@@ -902,10 +916,22 @@ class MainActivity : Activity(), SensorEventListener {
 
     private fun handleTrackpadTouch(view: View, event: MotionEvent): Boolean {
         val isAirMouse = mode == TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
+        val isMeta = mode == TapLinkBluetoothControllerServer.ControllerMode.META
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 val (x, y) = trackpadCentroid(event)
+                if (isMeta) {
+                    metaGestureStartX = x
+                    metaGestureStartY = y
+                    lastPadX = x
+                    lastPadY = y
+                    touchStartX = x
+                    touchStartY = y
+                    totalTouchDistance = 0f
+                    maxPointerCountInGesture = event.pointerCount
+                    return true
+                }
                 lastPadX = x
                 lastPadY = y
                 touchStartX = x
@@ -924,6 +950,10 @@ class MainActivity : Activity(), SensorEventListener {
                 return true
             }
             MotionEvent.ACTION_POINTER_DOWN -> {
+                if (isMeta) {
+                    maxPointerCountInGesture = maxOf(maxPointerCountInGesture, event.pointerCount)
+                    return true
+                }
                 flushPendingTrackpadDelta((event.pointerCount - 1).coerceAtLeast(1))
                 val (x, y) = trackpadCentroid(event)
                 resetTrackpadAccumulator(x, y, event.pointerCount)
@@ -937,11 +967,24 @@ class MainActivity : Activity(), SensorEventListener {
             }
             MotionEvent.ACTION_MOVE -> {
                 val (x, y) = trackpadCentroid(event)
+                if (isMeta) {
+                    val dx = x - lastPadX
+                    val dy = y - lastPadY
+                    totalTouchDistance += sqrt(dx * dx + dy * dy)
+                    lastPadX = x
+                    lastPadY = y
+                    maxPointerCountInGesture = maxOf(maxPointerCountInGesture, event.pointerCount)
+                    return true
+                }
                 processTrackpadSample(x, y, event.pointerCount, isAirMouse)
 
                 return true
             }
             MotionEvent.ACTION_POINTER_UP -> {
+                if (isMeta) {
+                    maxPointerCountInGesture = maxOf(maxPointerCountInGesture, event.pointerCount)
+                    return true
+                }
                 flushPendingTrackpadDelta(event.pointerCount)
                 val remainingPointerCount = (event.pointerCount - 1).coerceAtLeast(1)
                 val (x, y) = trackpadCentroid(event, excludeActionPointer = true)
@@ -956,6 +999,10 @@ class MainActivity : Activity(), SensorEventListener {
             }
             MotionEvent.ACTION_UP -> {
                 val (x, y) = trackpadCentroid(event)
+                if (isMeta) {
+                    sendMetaGestureKey(x, y)
+                    return true
+                }
                 processTrackpadSample(x, y, event.pointerCount, isAirMouse)
 
                 if (!isAirMouse) {
@@ -981,6 +1028,7 @@ class MainActivity : Activity(), SensorEventListener {
                 return true
             }
             MotionEvent.ACTION_CANCEL -> {
+                if (isMeta) return true
                 flushPendingTrackpadDelta(event.pointerCount)
                 if (!isAirMouse) {
                     controllerServer.sendTrackpadGesture(
@@ -993,6 +1041,22 @@ class MainActivity : Activity(), SensorEventListener {
         }
 
         return false
+    }
+
+    private fun sendMetaGestureKey(x: Float, y: Float) {
+        if (maxPointerCountInGesture > 1) return
+        val dx = x - metaGestureStartX
+        val dy = y - metaGestureStartY
+        val distance = sqrt(dx * dx + dy * dy)
+        val key =
+                if (distance < TAP_DISTANCE_PX && totalTouchDistance < TAP_DISTANCE_PX) {
+                    "Enter"
+                } else if (abs(dx) > abs(dy)) {
+                    if (dx < 0f) "ArrowLeft" else "ArrowRight"
+                } else {
+                    if (dy < 0f) "ArrowUp" else "ArrowDown"
+                }
+        controllerServer.sendKey(key)
     }
 
     private fun resetTrackpadAccumulator(x: Float, y: Float, pointerCount: Int) {
@@ -1085,8 +1149,11 @@ class MainActivity : Activity(), SensorEventListener {
 
     private fun updateModeChrome() {
         val isAirMouse = mode == TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
+        val isMeta = mode == TapLinkBluetoothControllerServer.ControllerMode.META
         trackpad.alpha = if (isAirMouse) 0.45f else 1f
         recenterButton.visibility = if (isAirMouse) View.VISIBLE else View.GONE
+        (trackpad as? ViewGroup)?.findViewById<TextView>(android.R.id.text1)?.text =
+                if (isMeta) "Meta Mode\nSwipe arrows • tap Enter" else "Trackpad Area"
     }
 
     private fun setPhoneKeyboardVisible(visible: Boolean) {

--- a/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
@@ -44,6 +44,8 @@ class MainActivity : Activity(), SensorEventListener {
 
     private lateinit var recenterButton: Button
     private lateinit var trackpad: View
+    private lateinit var metaControls: View
+    private lateinit var scrollBar: View
     private lateinit var keyboardPanel: LinearLayout
     private lateinit var phoneKeyboardInput: EditText
     private lateinit var apiKeyInput: EditText
@@ -568,7 +570,13 @@ class MainActivity : Activity(), SensorEventListener {
                 LinearLayout.LayoutParams(0, -1, 1f).apply { rightMargin = dp(8) }
         )
 
-        val scrollBar =
+        metaControls = buildMetaControls().apply { visibility = View.GONE }
+        trackpadContainer.addView(
+                metaControls,
+                LinearLayout.LayoutParams(0, -1, 1f).apply { rightMargin = dp(8) }
+        )
+
+        scrollBar =
                 FrameLayout(this).apply {
                     val shape =
                             android.graphics.drawable.GradientDrawable().apply {
@@ -839,6 +847,64 @@ class MainActivity : Activity(), SensorEventListener {
         inputRow.addView(clearBtn, LinearLayout.LayoutParams(dp(80), dp(52)))
         panel.addView(inputRow, LinearLayout.LayoutParams(-1, -2))
 
+        return panel
+    }
+
+    private fun buildMetaControls(): View {
+        val panel =
+                LinearLayout(this).apply {
+                    orientation = LinearLayout.VERTICAL
+                    gravity = Gravity.CENTER
+                    val shape =
+                            android.graphics.drawable.GradientDrawable().apply {
+                                setColor(Color.parseColor("#1e293b"))
+                                setStroke(dp(2), Color.parseColor("#334155"))
+                                cornerRadius = dp(24).toFloat()
+                            }
+                    background = shape
+                    setPadding(dp(20), dp(20), dp(20), dp(20))
+                }
+
+        fun arrowButton(label: String, key: String, color: String = "#334155") =
+                createModernButton(label, color).apply {
+                    textSize = 28f
+                    setOnClickListener { controllerServer.sendKey(key) }
+                }
+
+        fun rowParams() = LinearLayout.LayoutParams(-1, 0, 1f)
+        fun buttonParams() =
+                LinearLayout.LayoutParams(0, -1, 1f).apply {
+                    setMargins(dp(6), dp(6), dp(6), dp(6))
+                }
+        fun spacerParams() = LinearLayout.LayoutParams(0, 1, 1f)
+
+        panel.addView(
+                LinearLayout(this).apply {
+                    gravity = Gravity.CENTER
+                    addView(View(this@MainActivity), spacerParams())
+                    addView(arrowButton("▲", "ArrowUp"), buttonParams())
+                    addView(View(this@MainActivity), spacerParams())
+                },
+                rowParams()
+        )
+        panel.addView(
+                LinearLayout(this).apply {
+                    gravity = Gravity.CENTER
+                    addView(arrowButton("◀", "ArrowLeft"), buttonParams())
+                    addView(arrowButton("Enter", "Enter", "#3b82f6"), buttonParams())
+                    addView(arrowButton("▶", "ArrowRight"), buttonParams())
+                },
+                rowParams()
+        )
+        panel.addView(
+                LinearLayout(this).apply {
+                    gravity = Gravity.CENTER
+                    addView(View(this@MainActivity), spacerParams())
+                    addView(arrowButton("▼", "ArrowDown"), buttonParams())
+                    addView(View(this@MainActivity), spacerParams())
+                },
+                rowParams()
+        )
         return panel
     }
 
@@ -1150,10 +1216,12 @@ class MainActivity : Activity(), SensorEventListener {
     private fun updateModeChrome() {
         val isAirMouse = mode == TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
         val isMeta = mode == TapLinkBluetoothControllerServer.ControllerMode.META
+        trackpad.visibility = if (isMeta) View.GONE else View.VISIBLE
+        metaControls.visibility = if (isMeta) View.VISIBLE else View.GONE
+        scrollBar.visibility = if (isMeta) View.GONE else View.VISIBLE
         trackpad.alpha = if (isAirMouse) 0.45f else 1f
         recenterButton.visibility = if (isAirMouse) View.VISIBLE else View.GONE
-        (trackpad as? ViewGroup)?.findViewById<TextView>(android.R.id.text1)?.text =
-                if (isMeta) "Meta Mode\nSwipe arrows • tap Enter" else "Trackpad Area"
+        (trackpad as? ViewGroup)?.findViewById<TextView>(android.R.id.text1)?.text = "Trackpad Area"
     }
 
     private fun setPhoneKeyboardVisible(visible: Boolean) {

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
@@ -288,7 +288,8 @@ class TapLinkBluetoothControllerServer(private val context: Context) {
 
     enum class ControllerMode(val wireName: String) {
         AIR_MOUSE("airMouse"),
-        TRACKPAD("trackpad")
+        TRACKPAD("trackpad"),
+        META("meta")
     }
 
     enum class TouchAction(val wireName: String) {


### PR DESCRIPTION
### Motivation
- Add a lightweight "Meta mode" navigation mode where swipes map to arrow keys and taps map to Enter to improve compatibility with Glass Apps and controller workflows.
- Provide a user-toggle in settings and persist the preference so users can enable/disable the mode across restarts.
- Integrate Meta mode with existing controller modes and trackpad input so remote controllers can send meta keys.
- Hide or suppress the cursor when meta navigation is active to avoid conflicting input UX.

### Description
- Introduce a new preference key `Constants.KEY_META_MODE_ENABLED` and expose `setMetaModeEnabled(enabled: Boolean)` and `isMetaModeEnabled()` in `MainActivity` to persist and query mode state.
- Add a settings UI button `@id/btnToggleMetaMode` and wire it into `DualWebViewGroup` initialization and touch dispatch to toggle Meta mode and update its label.
- Implement Meta touch/trackpad handling in `MainActivity` via `handleMetaTouchEvent`, `metaKeyForGesture`, and `dispatchMetaKeyToWebView` so single-finger swipes produce `ArrowUp/Down/Left/Right` and taps produce `Enter`, and inject both Android key events and synthetic `KeyboardEvent` via JS for web compatibility.
- Integrate Meta mode with controller stack by adding a `META` value to `ControllerMode` in `ControllerInputProtocol` and `TapLinkBluetoothControllerServer`, parsing `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22efdc77a08320b50e52666a9266b0)