### PR TITLE
Add UDP keyboard transport with immediate-send and buffered fallback, plus UI updates

### DIFF
--- a/app/src/main/java/com/TapLink/app/controller/ControllerBluetoothClient.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerBluetoothClient.kt
@@ -315,8 +315,10 @@ class ControllerBluetoothClient(
                             }
                             "key" -> {
                                 val key = json.optString("key")
-
-                                handler.post { listener.onControllerKey(key) }
+                                val messageId = json.optString("messageId")
+                                if (ControllerReliableMessageDeduper.shouldDispatch(messageId)) {
+                                    handler.post { listener.onControllerKey(key) }
+                                }
                             }
                             "groqApiKey" -> {
                                 val key = json.optString("key")

--- a/app/src/main/java/com/TapLink/app/controller/ControllerInputProtocol.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerInputProtocol.kt
@@ -1,5 +1,25 @@
 package com.TapLinkX3.app.controller
 
+import java.util.LinkedHashMap
+
+object ControllerReliableMessageDeduper {
+    private const val CACHE_SIZE = 256
+    private val recentMessageIds =
+            object : LinkedHashMap<String, Unit>(CACHE_SIZE, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Unit>?): Boolean =
+                        size > CACHE_SIZE
+            }
+
+    fun shouldDispatch(messageId: String?): Boolean {
+        if (messageId.isNullOrEmpty()) return true
+        synchronized(recentMessageIds) {
+            if (recentMessageIds.containsKey(messageId)) return false
+            recentMessageIds[messageId] = Unit
+        }
+        return true
+    }
+}
+
 interface ControllerInputListener {
     fun onControllerConnected(name: String, address: String)
     fun onControllerDisconnected()

--- a/app/src/main/java/com/TapLink/app/controller/ControllerNetworkInputServer.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerNetworkInputServer.kt
@@ -86,7 +86,8 @@ class ControllerNetworkInputServer(
                     Log.d(TAG, "Network controller UDP receive active from ${packet.address.hostAddress}")
                 }
                 val line = String(packet.data, packet.offset, packet.length, Charsets.UTF_8)
-                sendAck(udpSocket, packet)
+                sendAck(udpSocket, packet, line)
+                if (isDuplicateReliableMessage(line)) continue
                 handleMessage(line)
             } catch (_: SocketException) {
                 if (isRunning.get()) Log.d(TAG, "Network input socket closed")
@@ -236,6 +237,9 @@ class ControllerNetworkInputServer(
         return if (end > start) json.substring(start, end) else null
     }
 
+    private fun isDuplicateReliableMessage(line: String): Boolean =
+            !ControllerReliableMessageDeduper.shouldDispatch(extractString(line, PREFIX_MESSAGE_ID))
+
     private fun parseTrackpadAction(value: String): ControllerTrackpadAction? =
             when (value) {
                 "down" -> ControllerTrackpadAction.DOWN
@@ -246,12 +250,10 @@ class ControllerNetworkInputServer(
                 else -> null
             }
 
-    private fun sendAck(udpSocket: DatagramSocket, packet: DatagramPacket) {
-        val data =
-                JSONObject()
-                        .put("type", TYPE_ACK)
-                        .toString()
-                        .toByteArray(Charsets.UTF_8)
+    private fun sendAck(udpSocket: DatagramSocket, packet: DatagramPacket, line: String) {
+        val ack = JSONObject().put("type", TYPE_ACK)
+        extractString(line, PREFIX_MESSAGE_ID)?.let { ack.put(FIELD_MESSAGE_ID, it) }
+        val data = ack.toString().toByteArray(Charsets.UTF_8)
         try {
             udpSocket.send(DatagramPacket(data, data.size, packet.address, PHONE_DISCOVERY_PORT))
         } catch (e: Exception) {
@@ -266,6 +268,7 @@ class ControllerNetworkInputServer(
         const val TYPE_ENDPOINT = "controllerNetworkEndpoint"
         private const val TYPE_ACK = "controllerNetworkAck"
         private const val TYPE_PING = "controllerNetworkPing"
+        private const val FIELD_MESSAGE_ID = "messageId"
         private const val DISCOVERY_INTERVAL_MS = 1000L
         private const val DISCOVERY_IDLE_INTERVAL_MS = 5000L
         private const val ACTIVE_THRESHOLD_MS = 10000L
@@ -276,5 +279,6 @@ class ControllerNetworkInputServer(
         private const val PREFIX_POINTER_COUNT = "\"pointerCount\":"
         private const val PREFIX_X = "\"x\":"
         private const val PREFIX_Y = "\"y\":"
+        private const val PREFIX_MESSAGE_ID = "\"messageId\":\""
     }
 }

--- a/app/src/main/java/com/TapLink/app/controller/ControllerNetworkInputServer.kt
+++ b/app/src/main/java/com/TapLink/app/controller/ControllerNetworkInputServer.kt
@@ -177,6 +177,15 @@ class ControllerNetworkInputServer(
                 val dy = extractFloat(line, PREFIX_DY) ?: return
                 handler.post { listener.onControllerScroll(dy) }
             }
+            "key" -> {
+                val key =
+                        try {
+                            JSONObject(line).optString("key")
+                        } catch (_: Exception) {
+                            return
+                        }
+                handler.post { listener.onControllerKey(key) }
+            }
         }
     }
 

--- a/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/MainActivity.kt
@@ -618,7 +618,10 @@ class MainActivity : Activity(), SensorEventListener {
                                             beforeLength: Int,
                                             afterLength: Int
                                     ): Boolean {
-                                        if (beforeLength == 1 && afterLength == 0) {
+                                        if (beforeLength == 1 &&
+                                                        afterLength == 0 &&
+                                                        shouldSendBackspaceImmediately()
+                                        ) {
                                             sendKeyEvent(
                                                     android.view.KeyEvent(
                                                             android.view.KeyEvent.ACTION_DOWN,
@@ -660,7 +663,8 @@ class MainActivity : Activity(), SensorEventListener {
 
                             setOnKeyListener { _, keyCode, event ->
                                 if (keyCode == android.view.KeyEvent.KEYCODE_DEL &&
-                                                event.action == android.view.KeyEvent.ACTION_DOWN
+                                                event.action == android.view.KeyEvent.ACTION_DOWN &&
+                                                shouldSendBackspaceImmediately()
                                 ) {
                                     controllerServer.sendKey("backspace")
                                     true
@@ -692,18 +696,12 @@ class MainActivity : Activity(), SensorEventListener {
                                         override fun afterTextChanged(s: Editable?) {
                                             if (suppressKeyboardTextChange) return
                                             val currentText = s?.toString().orEmpty()
-                                            if (currentText.length > beforeText.length) {
-                                                val added = currentText.substring(beforeText.length)
-                                                added.forEach { char ->
-                                                    controllerServer.sendKey(
-                                                            if (char == '\n') "enter"
-                                                            else char.toString()
-                                                    )
-                                                }
+                                            if (shouldSendTextImmediately(beforeText, currentText)) {
+                                                sendKeyboardText(currentText)
+                                                suppressKeyboardTextChange = true
+                                                s?.clear()
+                                                suppressKeyboardTextChange = false
                                             }
-                                            suppressKeyboardTextChange = true
-                                            s?.clear()
-                                            suppressKeyboardTextChange = false
                                         }
                                     }
                             )
@@ -714,10 +712,24 @@ class MainActivity : Activity(), SensorEventListener {
         )
 
         keyboardPanel.addView(
+                createModernButton("Send", "#10b981").apply {
+                    setOnClickListener { sendBufferedKeyboardText() }
+                },
+                LinearLayout.LayoutParams(dp(76), dp(52)).apply { rightMargin = dp(8) }
+        )
+
+        keyboardPanel.addView(
+                createModernButton("⌫", "#f97316").apply {
+                    setOnClickListener { controllerServer.sendKey("backspace") }
+                },
+                LinearLayout.LayoutParams(dp(56), dp(52)).apply { rightMargin = dp(8) }
+        )
+
+        keyboardPanel.addView(
                 createModernButton("Enter", "#8b5cf6").apply {
                     setOnClickListener { controllerServer.sendKey("enter") }
                 },
-                LinearLayout.LayoutParams(dp(80), dp(52)).apply { rightMargin = dp(8) }
+                LinearLayout.LayoutParams(dp(76), dp(52)).apply { rightMargin = dp(8) }
         )
 
         keyboardPanel.addView(
@@ -727,7 +739,7 @@ class MainActivity : Activity(), SensorEventListener {
                         setPhoneKeyboardVisible(false)
                     }
                 },
-                LinearLayout.LayoutParams(dp(80), dp(52))
+                LinearLayout.LayoutParams(dp(76), dp(52))
         )
         root.addView(keyboardPanel, LinearLayout.LayoutParams(-1, -2))
 
@@ -1087,6 +1099,26 @@ class MainActivity : Activity(), SensorEventListener {
         val isAirMouse = mode == TapLinkBluetoothControllerServer.ControllerMode.AIR_MOUSE
         trackpad.alpha = if (isAirMouse) 0.45f else 1f
         recenterButton.visibility = if (isAirMouse) View.VISIBLE else View.GONE
+    }
+
+    private fun shouldSendTextImmediately(beforeText: String, currentText: String): Boolean =
+            controllerServer.isKeyboardUdpAvailable() && beforeText.isEmpty() && currentText.isNotEmpty()
+
+    private fun shouldSendBackspaceImmediately(): Boolean =
+            controllerServer.isKeyboardUdpAvailable() && phoneKeyboardInput.text.isNullOrEmpty()
+
+    private fun sendBufferedKeyboardText() {
+        val text = phoneKeyboardInput.text?.toString().orEmpty()
+        if (text.isEmpty()) return
+
+        sendKeyboardText(text)
+        suppressKeyboardTextChange = true
+        phoneKeyboardInput.text?.clear()
+        suppressKeyboardTextChange = false
+    }
+
+    private fun sendKeyboardText(text: String) {
+        text.forEach { char -> controllerServer.sendKey(if (char == '\n') "enter" else char.toString()) }
     }
 
     private fun setPhoneKeyboardVisible(visible: Boolean) {

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
@@ -123,7 +123,11 @@ class TapLinkBluetoothControllerServer(private val context: Context) {
 
     fun sendKey(key: String) {
         val data = JSONObject().put("type", "key").put("key", key).toString()
-        if (!networkTransport.send(data)) {
+        val queuedReliable =
+                networkTransport.sendReliable(data) { reliableData ->
+                    writeRawToOutput(reliableData)
+                }
+        if (!queuedReliable) {
             sendRaw(data)
         }
     }

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkBluetoothControllerServer.kt
@@ -76,6 +76,8 @@ class TapLinkBluetoothControllerServer(private val context: Context) {
 
     fun isConnected(): Boolean = isConnected.get()
 
+    fun isKeyboardUdpAvailable(): Boolean = networkTransport.isReachable()
+
     fun setMode(mode: ControllerMode) {
         send(JSONObject().put("type", "mode").put("mode", mode.wireName))
     }
@@ -120,7 +122,10 @@ class TapLinkBluetoothControllerServer(private val context: Context) {
     }
 
     fun sendKey(key: String) {
-        send(JSONObject().put("type", "key").put("key", key))
+        val data = JSONObject().put("type", "key").put("key", key).toString()
+        if (!networkTransport.send(data)) {
+            sendRaw(data)
+        }
     }
 
     fun sendGroqApiKey(key: String) {

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkNetworkControllerTransport.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkNetworkControllerTransport.kt
@@ -61,6 +61,8 @@ class TapLinkNetworkControllerTransport {
         receiveThread = null
     }
 
+    fun isReachable(): Boolean = activeEndpoint.get() != null && socket != null && isUdpReachable()
+
     fun updateEndpoint(addresses: List<String>, port: Int) {
         val address =
                 addresses.asSequence()

--- a/controller/src/main/java/com/TapLinkX3/controller/TapLinkNetworkControllerTransport.kt
+++ b/controller/src/main/java/com/TapLinkX3/controller/TapLinkNetworkControllerTransport.kt
@@ -6,7 +6,11 @@ import java.net.DatagramSocket
 import java.net.Inet4Address
 import java.net.InetSocketAddress
 import java.net.SocketException
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -22,11 +26,16 @@ class TapLinkNetworkControllerTransport {
     private val lastProbeAtMs = AtomicLong(0L)
     private val latestDatagram = AtomicReference<PendingDatagram?>(null)
     private val latestSendScheduled = AtomicBoolean(false)
+    private val pendingReliableAcks = ConcurrentHashMap<String, CountDownLatch>()
     private var socket: DatagramSocket? = null
     private var receiveThread: Thread? = null
     private val sendExecutor =
             Executors.newSingleThreadExecutor { runnable ->
                 Thread(runnable, "TapLinkNetworkControllerSender").apply { isDaemon = true }
+            }
+    private val reliableSendExecutor =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "TapLinkNetworkControllerReliableSender").apply { isDaemon = true }
             }
 
     fun start() {
@@ -55,6 +64,7 @@ class TapLinkNetworkControllerTransport {
     fun stop() {
         isRunning.set(false)
         activeEndpoint.set(null)
+        pendingReliableAcks.clear()
         socket?.close()
         socket = null
         receiveThread?.interrupt()
@@ -71,6 +81,29 @@ class TapLinkNetworkControllerTransport {
                         .firstOrNull { !it.isLoopbackAddress && !it.isAnyLocalAddress }
                         ?: return
         updateEndpoint(InetSocketAddress(address, port))
+    }
+
+    fun sendReliable(data: String, fallback: (String) -> Unit): Boolean {
+        val endpoint = activeEndpoint.get() ?: return false
+        val udpSocket = socket ?: return false
+        if (!isUdpReachable()) {
+            sendProbe(endpoint)
+            return false
+        }
+
+        val messageId = UUID.randomUUID().toString()
+        val reliableData =
+                try {
+                    JSONObject(data).put(FIELD_MESSAGE_ID, messageId).toString()
+                } catch (e: Exception) {
+                    Log.d(TAG, "Reliable UDP payload was not JSON: ${e.message}")
+                    return false
+                }
+        val bytes = reliableData.toByteArray(Charsets.UTF_8)
+        reliableSendExecutor.execute {
+            sendReliableDatagram(udpSocket, endpoint, messageId, reliableData, bytes, fallback)
+        }
+        return true
     }
 
     fun send(data: String): Boolean {
@@ -146,6 +179,50 @@ class TapLinkNetworkControllerTransport {
         }
     }
 
+    private fun sendReliableDatagram(
+            udpSocket: DatagramSocket,
+            endpoint: InetSocketAddress,
+            messageId: String,
+            reliableData: String,
+            bytes: ByteArray,
+            fallback: (String) -> Unit
+    ) {
+        val latch = CountDownLatch(1)
+        pendingReliableAcks[messageId] = latch
+        try {
+            repeat(RELIABLE_SEND_ATTEMPTS) { attempt ->
+                try {
+                    udpSocket.send(
+                            DatagramPacket(bytes, bytes.size, endpoint.address, endpoint.port)
+                    )
+                    if (loggedActiveSend.compareAndSet(false, true)) {
+                        Log.d(TAG, "Network controller UDP send active")
+                    }
+                } catch (e: Exception) {
+                    Log.d(
+                            TAG,
+                            "Reliable network controller send failed: ${e.javaClass.simpleName}: ${e.message}"
+                    )
+                }
+
+                if (latch.await(RELIABLE_ACK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    return
+                }
+
+                if (attempt == 0) {
+                    Log.d(TAG, "Reliable UDP keyboard message retrying after missing ack")
+                }
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } finally {
+            pendingReliableAcks.remove(messageId)
+        }
+
+        Log.d(TAG, "Reliable UDP keyboard message failed; falling back to Bluetooth")
+        fallback(reliableData)
+    }
+
     private fun receiveLoop(udpSocket: DatagramSocket) {
         val buffer = ByteArray(2048)
         while (isRunning.get()) {
@@ -166,6 +243,10 @@ class TapLinkNetworkControllerTransport {
                     }
                     TYPE_ACK -> {
                         lastAckAtMs.set(System.currentTimeMillis())
+                        val messageId = json.optString(FIELD_MESSAGE_ID)
+                        if (messageId.isNotEmpty()) {
+                            pendingReliableAcks[messageId]?.countDown()
+                        }
                         Log.d(TAG, "Network controller UDP ack from ${packet.address.hostAddress}")
                     }
                 }
@@ -217,8 +298,11 @@ class TapLinkNetworkControllerTransport {
         const val TYPE_ENDPOINT = "controllerNetworkEndpoint"
         const val TYPE_ACK = "controllerNetworkAck"
         const val TYPE_PING = "controllerNetworkPing"
+        const val FIELD_MESSAGE_ID = "messageId"
         private const val UDP_ACK_STALE_MS = 3000L
         private const val UDP_PROBE_INTERVAL_MS = 500L
+        private const val RELIABLE_SEND_ATTEMPTS = 5
+        private const val RELIABLE_ACK_TIMEOUT_MS = 120L
     }
 
     private data class PendingDatagram(val bytes: ByteArray, val endpoint: InetSocketAddress)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -44,10 +44,11 @@ Gradle wrapper commands are available for CI:
 
 ## Controller networking
 
-The TapLink Controller still requires Bluetooth pairing, but high-frequency cursor input can use a UDP network lane when the phone and glasses can reach each other over Wi-Fi or Bluetooth-tethered networking.
+The TapLink Controller still requires Bluetooth pairing, but high-frequency cursor input and phone keyboard typing can use a UDP network lane when the phone and glasses can reach each other over Wi-Fi or Bluetooth-tethered networking.
 
 - Glasses UDP input port: `37693`
 - Phone UDP discovery port: `37692`
 - Bluetooth remains the fallback if UDP discovery or delivery is blocked.
+- When UDP is blocked, the controller keyboard switches to a local fill-and-send workflow to avoid sending every typed character through a laggy Bluetooth queue.
 
-For best input latency, keep both devices on the same reachable network path and avoid firewall/VPN rules that block local UDP broadcast or direct UDP packets between the devices.
+For best cursor and typing latency, keep both devices on the same reachable network path and avoid firewall/VPN rules that block local UDP broadcast or direct UDP packets between the devices.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -204,7 +204,7 @@ TapLink uses two controller transports at the same time:
 | **Bluetooth RFCOMM** | Pairing, mode changes, keyboard visibility, API-key sync, AI prompt handoff, and fallback input. | Required for automatic setup and compatibility. |
 | **UDP network lane** | Air mouse rays, trackpad movement, scroll, and phone keyboard keystrokes. | Preferred when available. Uses latest-position semantics for air mouse so stale packets are not replayed; keystrokes use ordered sends. |
 
-When UDP is available, keyboard characters are sent live as you type. If UDP is unavailable, the phone keyboard field acts as a compose box: type the text locally, tap **Send** to transmit it, or tap **⌫** next to Send to send a remote backspace.
+When UDP is available, keyboard characters are sent live as you type with per-message acknowledgement and retry; if UDP delivery still fails, the controller falls back to Bluetooth. If UDP is unavailable, the phone keyboard field acts as a compose box: type the text locally, tap **Send** to transmit it, or tap **⌫** next to Send to send a remote backspace.
 
 If cursor or phone keyboard input still feels delayed, confirm the phone and glasses can reach each other over the active network path and that UDP ports `37692` and `37693` are not blocked. If the UDP path is unavailable, TapLink continues over Bluetooth.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -185,7 +185,7 @@ When Scroll Mode is active, a small transparent **Show** button appears in the b
 
 ## TapLink Controller (Phone Companion App)
 
-The `controller` module builds a standalone Android phone app. Bluetooth is still required for pairing, discovery, keyboard visibility, API-key sync, and fallback input. High-frequency cursor input can also use a UDP network lane over Wi-Fi or Bluetooth-tethered networking, which avoids the latency and packet queueing limits of Bluetooth RFCOMM.
+The `controller` module builds a standalone Android phone app. Bluetooth is still required for pairing, discovery, keyboard visibility, API-key sync, and fallback input. Cursor and keyboard input can also use a UDP network lane over Wi-Fi or Bluetooth-tethered networking, which avoids the latency and packet queueing limits of Bluetooth RFCOMM.
 
 ### Setup
 1. **Pair** your phone and the RayNeo X3 glasses via Bluetooth settings.
@@ -193,7 +193,7 @@ The `controller` module builds a standalone Android phone app. Bluetooth is stil
 3. **Launch** the controller app. It starts the Bluetooth server automatically.
 4. **Launch** TapLink X3 on the glasses. The glasses client connects to the phone within a few seconds.
 5. The status bar shows **"Connected to TapLink glasses"** when linked.
-6. For the lowest-latency cursor path, keep the phone and glasses on the same IP network path. TapLink auto-discovers the glasses UDP input server on port `37693` by broadcast to phone port `37692`; if discovery is blocked, the glasses also send their network endpoint over Bluetooth after connecting.
+6. For the lowest-latency cursor and keyboard path, keep the phone and glasses on the same IP network path. TapLink auto-discovers the glasses UDP input server on port `37693` by broadcast to phone port `37692`; if discovery is blocked, the glasses also send their network endpoint over Bluetooth after connecting.
 
 ### Controller Transport
 
@@ -202,9 +202,11 @@ TapLink uses two controller transports at the same time:
 | Transport | Used for | Notes |
 | --- | --- | --- |
 | **Bluetooth RFCOMM** | Pairing, mode changes, keyboard visibility, API-key sync, AI prompt handoff, and fallback input. | Required for automatic setup and compatibility. |
-| **UDP network lane** | Air mouse rays, trackpad movement, and scroll. | Preferred when available. Uses latest-position semantics for air mouse so stale packets are not replayed. |
+| **UDP network lane** | Air mouse rays, trackpad movement, scroll, and phone keyboard keystrokes. | Preferred when available. Uses latest-position semantics for air mouse so stale packets are not replayed; keystrokes use ordered sends. |
 
-If cursor input still feels delayed, confirm the phone and glasses can reach each other over the active network path and that UDP ports `37692` and `37693` are not blocked. If the UDP path is unavailable, TapLink continues over Bluetooth.
+When UDP is available, keyboard characters are sent live as you type. If UDP is unavailable, the phone keyboard field acts as a compose box: type the text locally, tap **Send** to transmit it, or tap **⌫** next to Send to send a remote backspace.
+
+If cursor or phone keyboard input still feels delayed, confirm the phone and glasses can reach each other over the active network path and that UDP ports `37692` and `37693` are not blocked. If the UDP path is unavailable, TapLink continues over Bluetooth.
 
 ### Controls
 


### PR DESCRIPTION
### Motivation
- Reduce keyboard latency by using the existing UDP transport for phone keyboard keystrokes when the phone and glasses have a reachable network path and provide a local compose/send fallback when UDP is unavailable.
- Ensure the glasses can receive keyboard events via the network transport and handle them consistently with other controller inputs.

### Description
- Added `isReachable()` to `TapLinkNetworkControllerTransport` and `isKeyboardUdpAvailable()` to `TapLinkBluetoothControllerServer` to detect UDP availability.
- Modified `sendKey` to prefer sending the key JSON over UDP (`networkTransport.send`) and fall back to the existing Bluetooth/raw send when UDP is not reachable.
- Added handling for incoming `"type":"key"` messages in `ControllerNetworkInputServer` to extract the `key` field and dispatch `listener.onControllerKey`.
- Updated the phone controller UI and logic in `MainActivity` to send characters immediately over UDP when available, add a buffered compose flow with a `Send` button and `⌫` button, and implemented helper methods `shouldSendTextImmediately`, `shouldSendBackspaceImmediately`, `sendBufferedKeyboardText`, and `sendKeyboardText`.
- Documentation updates in `docs/SETUP.md` and `docs/USER_GUIDE.md` to describe keyboard-over-UDP behavior and the compose/send fallback.

### Testing
- Ran `./gradlew test` and the automated test suite completed successfully.
- Built the debug APK with `./gradlew :controller:assembleDebug` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2300840de48320b94381371b79ba98)