### PR TITLE
⚡ Bolt: Remove Pair allocations in hit testing paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -34,3 +34,6 @@
 ## 2024-05-18 - [Object Allocation in High-Frequency Paths]
 **Learning:** Allocating objects (like `FloatArray` and `Matrix`) inside high-frequency touch and hover loops (e.g., `computeAnchoredCoordinates` in `DualWebViewGroup`) creates massive memory churn, causing GC stutter and degraded UI responsiveness.
 **Action:** Pre-allocate all such math and measurement objects as class-level properties when optimizing Android View code.
+## 2024-05-19 - [Object Allocation in Getters called on Hot Paths]
+**Learning:** Returning `Pair<Float, Float>` or `Pair<Int, Int>` from helper getter functions (like `getSettingsMenuSize`, `getKeyboardSize`, or `getLocalPoint`) creates severe object allocation churn when these methods are called frequently inside high-frequency touch event loops.
+**Action:** Use an `out` parameter strategy. Have the calling method pass in a pre-allocated primitive array (e.g. `IntArray(2)` or `FloatArray(2)`). The getter populates the array rather than returning a newly instantiated object, keeping the touch event loop GC-friendly.

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -4854,8 +4854,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 localY <= keyboardContainer.bottom
     }
 
-    fun getKeyboardSize(): Pair<Int, Int> {
-        return Pair(keyboardContainer.width, keyboardContainer.height)
+    fun getKeyboardSize(outSize: IntArray) {
+        outSize[0] = keyboardContainer.width
+        outSize[1] = keyboardContainer.height
     }
 
     // Called from MainActivity when the cursor is over the keyboard
@@ -5604,28 +5605,28 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
     // Dispatch touch/click to the appropriate scrollbar element
     fun dispatchScrollbarTouch(screenX: Float, screenY: Float) {
-        fun getLocalPoint(container: ViewGroup): Pair<Float, Float>? {
-            if (container.visibility != View.VISIBLE) return null
+        fun getLocalPoint(container: ViewGroup, outPoint: FloatArray): Boolean {
+            if (container.visibility != View.VISIBLE) return false
 
-            if (!container.getGlobalVisibleRect(reusableRect)) return null
+            if (!container.getGlobalVisibleRect(reusableRect)) return false
             if (screenX < reusableRect.left ||
                             screenX > reusableRect.right ||
                             screenY < reusableRect.top ||
                             screenY > reusableRect.bottom
             ) {
-                return null
+                return false
             }
             val scaleX = if (container.scaleX == 0f) 1f else container.scaleX
             val scaleY = if (container.scaleY == 0f) 1f else container.scaleY
-            val localX = (screenX - reusableRect.left) / scaleX
-            val localY = (screenY - reusableRect.top) / scaleY
-            return localX to localY
+            outPoint[0] = (screenX - reusableRect.left) / scaleX
+            outPoint[1] = (screenY - reusableRect.top) / scaleY
+            return true
         }
 
         fun dispatchToContainer(container: ViewGroup) {
-            val localPoint = getLocalPoint(container) ?: return
-            val localX = localPoint.first
-            val localY = localPoint.second
+            if (!getLocalPoint(container, reusablePoint)) return
+            val localX = reusablePoint[0]
+            val localY = reusablePoint[1]
             // Check which child is hit
             for (i in 0 until container.childCount) {
                 val child = container.getChildAt(i)
@@ -6370,8 +6371,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         settingsMenu?.getLocationOnScreen(location)
     }
 
-    fun getSettingsMenuSize(): Pair<Int, Int> {
-        return Pair(settingsMenu?.width ?: 0, settingsMenu?.height ?: 0)
+    fun getSettingsMenuSize(outSize: IntArray) {
+        outSize[0] = settingsMenu?.width ?: 0
+        outSize[1] = settingsMenu?.height ?: 0
     }
 
     fun dispatchSettingsTouchEvent(x: Float, y: Float) {

--- a/app/src/main/java/com/TapLink/app/MainActivity.kt
+++ b/app/src/main/java/com/TapLink/app/MainActivity.kt
@@ -141,6 +141,7 @@ class MainActivity :
     private val Y_INVERT = -1.0f // 1 = drag up -> up. Use -1 to flip if needed.
     lateinit var dualWebViewGroup: DualWebViewGroup
     private val reusableLocation1 = IntArray(2)
+    private val reusableLocation2 = IntArray(2)
     private lateinit var webView: WebView
     private lateinit var mainContainer: FrameLayout
     private lateinit var gestureDetector: GestureDetector
@@ -2843,12 +2844,13 @@ class MainActivity :
         if (dualWebViewGroup.isSettingsVisible()) {
             val settingsMenuLocation = reusableLocation1
             dualWebViewGroup.getSettingsMenuLocation(settingsMenuLocation)
-            val settingsMenuSize = dualWebViewGroup.getSettingsMenuSize()
+            val settingsMenuSize = reusableLocation2
+            dualWebViewGroup.getSettingsMenuSize(settingsMenuSize)
 
             if (interactionX >= settingsMenuLocation[0] &&
-                            interactionX <= settingsMenuLocation[0] + settingsMenuSize.first &&
+                            interactionX <= settingsMenuLocation[0] + settingsMenuSize[0] &&
                             interactionY >= settingsMenuLocation[1] &&
-                            interactionY <= settingsMenuLocation[1] + settingsMenuSize.second
+                            interactionY <= settingsMenuLocation[1] + settingsMenuSize[1]
             ) {
 
                 // Dispatch touch event to settings menu using screen coordinates
@@ -3378,11 +3380,12 @@ class MainActivity :
         if (dualWebViewGroup.isSettingsVisible()) {
             val settingsMenuLocation = reusableLocation1
             dualWebViewGroup.getSettingsMenuLocation(settingsMenuLocation)
-            val settingsMenuSize = dualWebViewGroup.getSettingsMenuSize()
+            val settingsMenuSize = reusableLocation2
+            dualWebViewGroup.getSettingsMenuSize(settingsMenuSize)
             if (screenX >= settingsMenuLocation[0] &&
-                            screenX <= settingsMenuLocation[0] + settingsMenuSize.first &&
+                            screenX <= settingsMenuLocation[0] + settingsMenuSize[0] &&
                             screenY >= settingsMenuLocation[1] &&
-                            screenY <= settingsMenuLocation[1] + settingsMenuSize.second
+                            screenY <= settingsMenuLocation[1] + settingsMenuSize[1]
             ) {
                 return true
             }
@@ -3551,11 +3554,12 @@ class MainActivity :
         if (dualWebViewGroup.isSettingsVisible()) {
             val settingsMenuLocation = reusableLocation1
             dualWebViewGroup.getSettingsMenuLocation(settingsMenuLocation)
-            val settingsMenuSize = dualWebViewGroup.getSettingsMenuSize()
+            val settingsMenuSize = reusableLocation2
+            dualWebViewGroup.getSettingsMenuSize(settingsMenuSize)
             if (rawScreenX >= settingsMenuLocation[0] &&
-                            rawScreenX <= settingsMenuLocation[0] + settingsMenuSize.first &&
+                            rawScreenX <= settingsMenuLocation[0] + settingsMenuSize[0] &&
                             rawScreenY >= settingsMenuLocation[1] &&
-                            rawScreenY <= settingsMenuLocation[1] + settingsMenuSize.second
+                            rawScreenY <= settingsMenuLocation[1] + settingsMenuSize[1]
             ) {
                 dualWebViewGroup.dispatchSettingsTouchEvent(rawScreenX, rawScreenY)
                 return true


### PR DESCRIPTION
💡 **What:** The optimization implemented
Replaced the `Pair` return types in `getLocalPoint`, `getKeyboardSize`, and `getSettingsMenuSize` with primitive arrays passed as out parameters (e.g. `FloatArray(2)` and `IntArray(2)`).

🎯 **Why:** The performance problem it solves
These getter methods were being called continuously during touch and hover events. Returning a newly allocated `Pair` object on every call forced the Android Garbage Collector to run frequently, causing dropped frames and noticeable UI stutter during interactions.

📊 **Impact:** Expected performance improvement
Eliminates hundreds of object allocations per second during active interaction, significantly reducing GC pressure and improving the smoothness of cursor movement and hit testing.

🔬 **Measurement:** How to verify the improvement
Observe Android Studio Memory Profiler while actively moving the cursor around the screen. The sawtooth pattern indicative of frequent garbage collection should be noticeably flattened compared to the unoptimized build.

---
*PR created automatically by Jules for task [3737579913945477736](https://jules.google.com/task/3737579913945477736) started by @informalTechCode*