### PR TITLE
⚡ Bolt: Refactor getHitRect to avoid mutable shared state bugs

### DIFF
--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -6395,29 +6395,28 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
             val resetTextColorButton = menu.findViewById<Button>(R.id.btnResetTextColor)
             val groqKeyButton = menu.findViewById<Button>(R.id.btnGroqApiKey)
 
-            fun getHitRect(view: View?, slopPx: Int): Rect? {
-                if (view == null || view.visibility != View.VISIBLE) return null
-                if (!view.getGlobalVisibleRect(reusableRect)) return null
-                if (x >= reusableRect.left - slopPx &&
-                        x <= reusableRect.right + slopPx &&
-                        y >= reusableRect.top - slopPx &&
-                        y <= reusableRect.bottom + slopPx) {
-                    return reusableRect
-                }
-                return null
+            // 💡 What: Modified getHitRect to use an `outRect` parameter and return Boolean instead of returning `Rect?`
+            // 🎯 Why: Returning a pre-allocated object (reusableRect) directly can create brittle code if calling functions hold onto the reference, leading to shared mutable state bugs.
+            // 📊 Impact: Improves code safety and prevents potential bugs from shared mutable state while avoiding object allocation churn.
+            fun getHitRect(view: View?, slopPx: Int, outRect: Rect): Boolean {
+                if (view == null || view.visibility != View.VISIBLE) return false
+                if (!view.getGlobalVisibleRect(outRect)) return false
+                return x >= outRect.left - slopPx &&
+                        x <= outRect.right + slopPx &&
+                        y >= outRect.top - slopPx &&
+                        y <= outRect.bottom + slopPx
             }
 
             val menuSlop = (2f * uiScale).roundToInt()
             val sliderSlop = (1f * uiScale).roundToInt()
             val buttonSlop = (3f * uiScale).roundToInt()
 
-            if (getHitRect(menu, menuSlop) != null) {
+            if (getHitRect(menu, menuSlop, reusableRect)) {
                 // Check if click is on volume seekbar
-                val volumeRect = getHitRect(volumeSeekBar, sliderSlop)
-                if (volumeRect != null) {
+                if (getHitRect(volumeSeekBar, sliderSlop, reusableRect)) {
 
                     // Calculate relative position on seekbar
-                    val relativeX = (x - volumeRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, volumeSeekBar.width.toFloat()) /
                                     volumeSeekBar.width
@@ -6444,11 +6443,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on brightness seekbar
-                val brightnessRect = getHitRect(brightnessSeekBar, sliderSlop)
-                if (brightnessRect != null) {
+                if (getHitRect(brightnessSeekBar, sliderSlop, reusableRect)) {
 
                     // Calculate relative position on seekbar
-                    val relativeX = (x - brightnessRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, brightnessSeekBar.width.toFloat()) /
                                     brightnessSeekBar.width
@@ -6469,8 +6467,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on force dark toggle button
-                val forceDarkRect = getHitRect(forceDarkButton, buttonSlop)
-                if (forceDarkRect != null) {
+                if (getHitRect(forceDarkButton, buttonSlop, reusableRect)) {
                     val prefs = context.getSharedPreferences("TapLinkPrefs", Context.MODE_PRIVATE)
                     val currentlyEnabled = prefs.getBoolean("forceDarkWebEnabled", true)
                     val newEnabled = !currentlyEnabled
@@ -6484,11 +6481,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on smoothness seekbar
-                val smoothnessRect = getHitRect(smoothnessSeekBar, sliderSlop)
-                if (smoothnessRect != null) {
+                if (getHitRect(smoothnessSeekBar, sliderSlop, reusableRect)) {
 
                     // Calculate relative position on seekbar
-                    val relativeX = (x - smoothnessRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, smoothnessSeekBar.width.toFloat()) /
                                     smoothnessSeekBar.width
@@ -6515,10 +6511,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
                 // Check if click is on cursor sensitivity seekbar
                 val sensitivitySeekBar = menu.findViewById<SeekBar>(R.id.cursorSensitivitySeekBar)
-                val sensitivityRect = getHitRect(sensitivitySeekBar, sliderSlop)
-                if (sensitivityRect != null) {
+                if (getHitRect(sensitivitySeekBar, sliderSlop, reusableRect)) {
                     // Calculate relative position on seekbar
-                    val relativeX = (x - sensitivityRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, sensitivitySeekBar.width.toFloat()) /
                                     sensitivitySeekBar.width
@@ -6544,8 +6539,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 // Check if click is on reset sensitivity button
                 val resetSensitivityButton =
                         menu.findViewById<Button>(R.id.btnResetCursorSensitivity)
-                val resetSensitivityRect = getHitRect(resetSensitivityButton, buttonSlop)
-                if (resetSensitivityRect != null) {
+                if (getHitRect(resetSensitivityButton, buttonSlop, reusableRect)) {
                     // Reset to 50%
                     // val sensitivitySeekBar =
                     //        menu.findViewById<SeekBar>(R.id.cursorSensitivitySeekBar)
@@ -6566,11 +6560,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on screen size seekbar
-                val screenSizeRect = getHitRect(screenSizeSeekBar, sliderSlop)
-                if (screenSizeRect != null) {
+                if (getHitRect(screenSizeSeekBar, sliderSlop, reusableRect)) {
 
                     // Calculate relative position on seekbar
-                    val relativeX = (x - screenSizeRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, screenSizeSeekBar.width.toFloat()) /
                                     screenSizeSeekBar.width
@@ -6632,8 +6625,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on Groq API Key button
-                val groqKeyRect = getHitRect(groqKeyButton, buttonSlop)
-                if (groqKeyRect != null) {
+                if (getHitRect(groqKeyButton, buttonSlop, reusableRect)) {
 
                     // Visual feedback
                     groqKeyButton.isPressed = true
@@ -6650,8 +6642,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on reset screen size button
-                val resetScreenSizeRect = getHitRect(resetScreenSizeButton, buttonSlop)
-                if (resetScreenSizeRect != null) {
+                if (getHitRect(resetScreenSizeButton, buttonSlop, reusableRect)) {
 
                     // Reset screen size to 100%
                     screenSizeSeekBar?.progress = 100
@@ -6703,10 +6694,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on horizontal pos seekbar
-                val horizontalPosRect = getHitRect(horizontalPosSeekBar, sliderSlop)
-                if (horizontalPosRect != null) {
+                if (getHitRect(horizontalPosSeekBar, sliderSlop, reusableRect)) {
 
-                    val relativeX = (x - horizontalPosRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, horizontalPosSeekBar.width.toFloat()) /
                                     horizontalPosSeekBar.width
@@ -6728,10 +6718,9 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on vertical pos seekbar
-                val verticalPosRect = getHitRect(verticalPosSeekBar, sliderSlop)
-                if (verticalPosRect != null) {
+                if (getHitRect(verticalPosSeekBar, sliderSlop, reusableRect)) {
 
-                    val relativeX = (x - verticalPosRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, verticalPosSeekBar.width.toFloat()) /
                                     verticalPosSeekBar.width
@@ -6753,8 +6742,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on reset button
-                val resetRect = getHitRect(resetButton, buttonSlop)
-                if (resetRect != null) {
+                if (getHitRect(resetButton, buttonSlop, reusableRect)) {
 
                     // Reset position progress to 50 (center)
                     horizontalPosSeekBar?.progress = 50
@@ -6776,8 +6764,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on help button
-                val helpRect = getHitRect(helpButton, buttonSlop)
-                if (helpRect != null) {
+                if (getHitRect(helpButton, buttonSlop, reusableRect)) {
 
                     // Visual feedback
                     helpButton.isPressed = true
@@ -6795,8 +6782,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
                 // Check if click is on Reset Zoom button
                 val resetZoomButton = menu.findViewById<Button>(R.id.btnResetFontSize)
-                val resetZoomRect = getHitRect(resetZoomButton, buttonSlop)
-                if (resetZoomRect != null) {
+                if (getHitRect(resetZoomButton, buttonSlop, reusableRect)) {
 
                     // Reset font size to 100% (progress 50)
                     fontSizeSeekBar?.progress = 50
@@ -6821,8 +6807,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 
                 // Check if click is on Reset Webpage Zoom button
                 val resetWebpageZoomButton = menu.findViewById<Button>(R.id.btnResetWebpageZoom)
-                val resetWebpageZoomRect = getHitRect(resetWebpageZoomButton, buttonSlop)
-                if (resetWebpageZoomRect != null) {
+                if (getHitRect(resetWebpageZoomButton, buttonSlop, reusableRect)) {
 
                     // Reset webpage zoom to 1.0
                     currentWebZoom = 1.0f
@@ -6858,11 +6843,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on font size seekbar
-                val fontSizeRect = getHitRect(fontSizeSeekBar, sliderSlop)
-                if (fontSizeRect != null) {
+                if (getHitRect(fontSizeSeekBar, sliderSlop, reusableRect)) {
 
                     // Calculate relative position on seekbar
-                    val relativeX = (x - fontSizeRect!!.left) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
                     val percentage =
                             relativeX.coerceIn(0f, fontSizeSeekBar.width.toFloat()) /
                                     fontSizeSeekBar.width
@@ -6890,12 +6874,11 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on color wheel
-                val colorWheelRect = getHitRect(colorWheelView, sliderSlop)
-                if (colorWheelRect != null) {
+                if (getHitRect(colorWheelView, sliderSlop, reusableRect)) {
 
                     // Calculate relative position
-                    val relativeX = (x - colorWheelRect!!.left) / uiScale
-                    val relativeY = (y - colorWheelRect.top) / uiScale
+                    val relativeX = (x - reusableRect.left) / uiScale
+                    val relativeY = (y - reusableRect.top) / uiScale
 
                     val selectedColor =
                             colorWheelView.calculateColorFromCoordinates(relativeX, relativeY)
@@ -6915,8 +6898,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on reset text color button
-                val resetTextColorRect = getHitRect(resetTextColorButton, buttonSlop)
-                if (resetTextColorRect != null) {
+                if (getHitRect(resetTextColorButton, buttonSlop, reusableRect)) {
 
                     // Reset color to white
                     colorWheelView?.setColor(Color.WHITE)
@@ -6932,8 +6914,7 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
                 }
 
                 // Check if click is on close button
-                val closeRect = getHitRect(closeButton, buttonSlop)
-                if (closeRect != null) {
+                if (getHitRect(closeButton, buttonSlop, reusableRect)) {
 
                     // Visual feedback
                     closeButton.isPressed = true


### PR DESCRIPTION
This PR refactors `getHitRect` within `DualWebViewGroup.kt`'s `dispatchSettingsTouchEvent` method to avoid returning a pre-allocated `Rect` object directly. 

### 💡 What
Modified the helper function `getHitRect` to take an `outRect: Rect` as a parameter and return a `Boolean` indicating if a hit occurred. All call sites were updated to pass `reusableRect` explicitly and evaluate the boolean result.

### 🎯 Why
Addresses the known anti-pattern: "Mutable Shared State in Utility Functions", as documented in `.jules/bolt.md`. Returning a shared mutable instance (like `reusableRect`) directly can create brittle code if calling functions inadvertently hold onto references.

### 📊 Impact
Improves code safety, predictability, and enforces proper lifecycle scoping for shared objects without sacrificing performance. Avoiding object creation inside the touch loop keeps memory footprint and GC churn near zero.

### 🔬 Measurement
Tests pass locally (`./gradlew test`) and the project compiles cleanly (`./gradlew lint`). Verify visually by launching Settings and interacting with the UI.

---
*PR created automatically by Jules for task [11056320825252889825](https://jules.google.com/task/11056320825252889825) started by @informalTechCode*