### PR TITLE
⚡ Bolt: Remove expensive object iterators and unneeded relayouts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,6 @@
 ## 2024-05-19 - Removed Iterator Allocations in High Frequency Touch Event
 **Learning:** `NavButton` map iteration created Iterator and Entry allocations on every UI touch event dispatch in `DualWebViewGroup.kt` `handleNavigationClick`. This caused GC churn and frame drops.
 **Action:** Always prefer indexed loops (`for (i in 0 until list.size)`) over Collections iterators or Map `.entries`/`.values` for high-frequency code paths like UI events or drawing passes.
+## 2024-05-19 - Remove requestLayout from CustomKeyboardView
+**Learning:** Calling `requestLayout()` unnecessarily inside high-frequency view update methods (like `updateKeyFocus` or hover callbacks) forces the entire view hierarchy to recalculate its bounds. This is extremely expensive when just changing background or text colors, which only require an `invalidate()` (draw phase update).
+**Action:** Never call `requestLayout()` unless the view's dimensions or position have changed. When updating simple visual properties like background color, `invalidate()` is sufficient.

--- a/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
+++ b/app/src/main/java/com/TapLink/app/CustomKeyboardView.kt
@@ -631,8 +631,9 @@ class CustomKeyboardView @JvmOverloads constructor(context: Context, attrs: Attr
             button.invalidate()
         }
 
+        // Bolt optimization: Removed requestLayout() here as updating text/background
+        // colors does not change bounds, saving expensive layout passes.
         invalidate()
-        requestLayout()
 
         if (!isSyncing) {
             syncWithParent()

--- a/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
+++ b/app/src/main/java/com/TapLink/app/DualWebViewGroup.kt
@@ -5813,7 +5813,10 @@ constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
         }
 
         if (leftToggleBar.visibility == View.VISIBLE) {
-            for (target in toggleHoverTargets) {
+            // Bolt optimization: Use indexed loop to prevent Iterator allocation in touch handler
+            val targets = toggleHoverTargets
+            for (i in 0 until targets.size) {
+                val target = targets[i]
                 if (isOver(target.view, screenX, screenY)) {
                     handleLeftMenuAction(target.id)
                     return


### PR DESCRIPTION
💡 What: Removed `requestLayout()` from the `updateKeyFocus` method in `CustomKeyboardView.kt` and converted a `.forEach` style `toggleHoverTargets` iterator into an indexed `for` loop in `DualWebViewGroup.kt`.
🎯 Why: `requestLayout()` triggered full layout passes unnecessarily during high-frequency UI updates. The iterator allocation created GC churn on touch events.
📊 Impact: Considerably reduces UI stutter during hover state tracking.
🔬 Measurement: Verify smoothness improvements while touching/hovering keyboard keys and UI toggle buttons without triggering large log spikes from GC.

---
*PR created automatically by Jules for task [8474028650482516699](https://jules.google.com/task/8474028650482516699) started by @informalTechCode*